### PR TITLE
V0.2.0/release review

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,4 +1,4 @@
 # Used by "mix format"
 [
-  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test,native,bench}/**/*.{ex,exs}"]
 ]

--- a/.github/workflows/elixir-build.yml
+++ b/.github/workflows/elixir-build.yml
@@ -64,4 +64,4 @@ jobs:
         run: mix compile --warnings-as-errors
 
       - name: Run tests
-        run: mix test
+        run: mix test ${{ matrix.coverage && '--cover' || '' }}

--- a/.github/workflows/precompiled-nifs.yml
+++ b/.github/workflows/precompiled-nifs.yml
@@ -249,7 +249,7 @@ jobs:
         run: mix compile
 
       - name: Generate checksum file from GitHub Release
-        run: mix zigler_precompiled.download GraphBLAS.Native.SuiteSparse --all --print 2>/dev/null
+        run: mix zigler_precompiled.download GraphBLAS.Native.SuiteSparse --all --print
 
       - name: Publish to Hex
         run: mix hex.publish --yes

--- a/.github/workflows/precompiled-nifs.yml
+++ b/.github/workflows/precompiled-nifs.yml
@@ -224,10 +224,36 @@ jobs:
           otp-version: "27"
           elixir-version: "1.18.4"
 
-      - name: Install SuiteSparse
+      - name: Install build dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libgraphblas-dev pkg-config
+          sudo apt-get install -y pkg-config build-essential cmake
+
+      - name: Cache GraphBLAS v9.4.5
+        uses: actions/cache@v4
+        id: graphblas-cache-publish
+        with:
+          path: |
+            /usr/local/lib/libgraphblas.so*
+            /usr/local/include/suitesparse/GraphBLAS.h
+            /usr/local/lib/pkgconfig/GraphBLAS.pc
+          key: graphblas-v9.4.5-publish
+
+      - name: Build and install GraphBLAS v9.4.5
+        if: steps.graphblas-cache-publish.outputs.cache-hit != 'true'
+        run: |
+          git clone --depth 1 --branch v9.4.5 https://github.com/DrTimothyAldenDavis/GraphBLAS.git
+          cmake -S GraphBLAS -B GraphBLAS/build -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local -DGRAPHBLAS_BUILD_PKGCONFIG=ON
+          cmake --build GraphBLAS/build -j"$(nproc)"
+          sudo cmake --install GraphBLAS/build
+          sudo ldconfig
+          rm -rf GraphBLAS
+
+      - name: Configure library paths
+        run: |
+          echo "PKG_CONFIG_PATH=/usr/local/lib/pkgconfig" >> "$GITHUB_ENV"
+          echo "LD_LIBRARY_PATH=/usr/local/lib" >> "$GITHUB_ENV"
+          sudo ldconfig
 
       - name: Restore Mix dependencies cache
         uses: actions/cache@v4
@@ -249,7 +275,7 @@ jobs:
         run: mix compile
 
       - name: Generate checksum file from GitHub Release
-        run: mix zigler_precompiled.download GraphBLAS.Native.SuiteSparse --all --print
+        run: mix zigler_precompiled.download GraphBLAS.Native.SuiteSparse --all --print --ignore-unavailable
 
       - name: Publish to Hex
         run: mix hex.publish --yes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,39 +1,104 @@
 # Changelog
 
-## 0.2.0 (Unreleased)
+## 0.2.0
+
+First public release to Hex.pm.
+
+### Highlights
+
+- **Three-backend architecture**: Pure Elixir (reference), SuiteSparse:GraphBLAS (native
+  performance via Zigler NIFs), and ZigStub (CI verification without native dependencies).
+- **Precompiled NIFs** for 6 platforms: aarch64/x86\_64 on Linux (glibc and musl) and macOS.
+  End users do not need Zig or SuiteSparse installed.
+- **Backend behaviour** (`GraphBLAS.Backend`) with 30 callbacks. All three backends implement
+  the same contract, enforced by `@behaviour`.
+- **7 graph algorithms** and a knowledge-graph query layer (`GraphBLAS.Relation`).
+- **392 tests**, including property-based tests (StreamData), edge-case coverage, and
+  algebraic-property verification. 0 failures, 3 skipped (SuiteSparse-only).
 
 ### Added
 
-- `backend` field in `%Matrix{}` and `%Vector{}` structs for robust backend dispatch.
+- `GraphBLAS.Backend` behaviour with 30 `@callback` definitions.
+- `GraphBLAS.Backend.Elixir` -- pure Elixir reference backend (COO maps).
+- `GraphBLAS.Backend.SuiteSparse` -- native SuiteSparse:GraphBLAS backend via Zigler NIFs.
+- `GraphBLAS.Backend.ZigStub` -- minimal Zig NIF backend for CI verification.
+- `backend` field in `%Matrix{}` and `%Vector{}` structs for correct dispatch.
   Inspection functions (`nvals`, `to_entries`, `to_coo`, `to_list`, `to_dense`) now
-  dispatch via the owning backend instead of always defaulting to Elixir.
+  dispatch via the owning backend.
+- Conditional compilation: SuiteSparse modules live in `native/` and are only compiled
+  when `EX_GRAPHBLAS_COMPILE_NATIVE=1` (test/dev) or in `dev.exs`/`config.exs`.
+- Precompiled NIF distribution via ZiglerPrecompiled and GitHub Releases for 6 targets:
+  `aarch64-linux-gnu`, `aarch64-linux-musl`, `aarch64-macos-none`, `x86_64-linux-gnu`,
+  `x86_64-linux-musl`, `x86_64-macos-none`.
 - SuiteSparse include path configurable via `SUITESPARSE_INCLUDE_PATH` environment
-  variable or `:suitesparse_include_path` config key. Platform-specific defaults.
+  variable or `:suitesparse_include_path` config key.
+- 7 graph algorithms: `bfs_reach`, `bfs_levels`, `sssp`, `triangle_count`,
+  `connected_components`, `degree`, `pagerank`.
+- `GraphBLAS.Relation` module for knowledge-graph modelling with `traverse/4`,
+  `closure/4` (with `:max_iter` option), and `fixed_point/3`.
+- 12 built-in semirings including `:min_plus`, `:min_plus_fp64`, `:max_plus`,
+  `:max_plus_fp64`, `:max_min`, `:max_min_fp64`.
+- `sssp/3` accepts `:infinity` option (default: `1.0e18`).
+- `closure/4` accepts `:max_iter` option (default: `100`).
 - Core operations benchmark suite (`bench/core_ops_benchmarks.exs`).
-- Benchmark runner script (`bench/run_all.exs`).
-- Installation guide (`guides/installation_guide.md`).
+- Edge-case test suite (22 tests): zero-dimension containers, negative dimensions,
+  out-of-bounds indices, all type variants, operations on empty containers.
+- Algebraic property test suite (17 tests): commutativity, associativity, transpose
+  involution, dup independence, reduce correctness.
+- ZigStub dimension validation guards matching the Elixir backend.
+- `@doc` additions: `Raises KeyError` on `new/1` for BinaryOp, UnaryOp, Monoid,
+  Semiring; `Raises ArgumentError` on `fn_for/1` for BinaryOp, UnaryOp.
+- `Logger.debug` in `application.ex` rescue blocks for SuiteSparse init/finalize
+  failures.
+- Comprehensive guides: installation, architecture walkthrough, reference backend
+  walkthrough, native backend walkthrough, graph algorithms, masks and descriptors,
+  parity testing.
 - Apache License 2.0.
 - `coveralls.json` for coverage configuration.
 
 ### Fixed
 
+- **Resource leaks**: Transposed matrices in `matrix_mxm`, `matrix_mxv`, `vector_vxm`
+  are now freed in `after` blocks via `maybe_free_transposed/2`.
+- **Ignored Zig error codes**: Replaced 22 instances of `_ = GrB_*()` with
+  `try translate_info(GrB_*())` for dimension queries, type queries, descriptor set,
+  JIT disable, and finalize. Only `_free` calls remain unhandled (correct -- nothing
+  to do on free failure).
+- **Silent type defaults**: `type_code_to_grb_type`, `semiring_from_code`,
+  `monoid_from_code` now return errors instead of silently defaulting to INT64.
+- **Zig build buffer overread**: Added bounds checks (`nvals > *.len`) to all 6 build
+  functions in `graphblas.zig`.
+- **Unsafe `hd()` call**: `algorithm.ex` uses pattern match `[{v, _} | _]` instead of
+  `hd(unvisited_entries)`.
 - `Vector.nvals/1`, `Vector.to_entries/1`, `Vector.to_list/1` now correctly dispatch
-  to the backend that created the vector. Previously always used Elixir backend,
-  causing runtime errors on SuiteSparse vectors.
+  to the backend that created the vector.
 - `Matrix.nvals/1`, `Matrix.to_coo/1`, `Matrix.to_dense/1` same dispatch fix.
 - `Matrix.set/5`, `Matrix.extract/4`, `Vector.set/4`, `Vector.extract/3` now use
-  the container's backend instead of ignoring the backend parameter.
-- `config/config.exs` updated to reflect SuiteSparse backend availability.
-- Removed private `vector_to_entries/1` and `matrix_to_coo/1` helpers from
-  `algorithm.ex` — public API now handles backend dispatch correctly.
-- Moved `bench_data.ex` from `lib/` to `bench/` (benchmark-only code).
-- Fixed `Range.new` deprecation warning in `BenchData.undirected_random_graph/2`.
+  the container's backend.
+- Precompiled NIF targets restricted to the 6 platforms we actually build (was
+  defaulting to 12, causing 404s on `arm-linux-gnueabihf` etc.).
+- `publish_hex` CI job builds GraphBLAS v9.4.5 from source instead of using Ubuntu's
+  v7.4.0 `libgraphblas-dev` (which lacks `GrB_Descriptor_set_INT32`).
+- Fixed `Range.new` deprecation warning.
+- Fixed OTP 27 `+0.0` float literal warnings.
 
 ### Changed
 
-- `README.md` overhauled to reflect Phases 1-6 completion.
-- `mix.exs` updated with package metadata for Hex.pm.
-- Credo clean (0 issues).
+- `mix.exs`: added `source_url`, `source_ref`, explicit `files:` list. Elixir
+  requirement changed from `~> 1.17` to `~> 1.18`. Prod `elixirc_paths` is `["lib"]`
+  only (users don't need SuiteSparse headers to compile).
+- `apply/3` calls replaced with dynamic module call syntax (`mod.func(args)`) to
+  satisfy Credo.
+- Duplicate `max_int`/`min_int` private functions in `monoid.ex` replaced with
+  `@int64_max`/`@int64_min` module attributes.
+- CI: `elixir-build.yml` caches only `deps/` (not `_build/`), preventing stale NIF
+  `.so` issues. Cache keys include source file hashes.
+- CI: `precompiled-nifs.yml` uses `--ignore-unavailable` as a safety net during
+  checksum generation.
+- Guides updated to reflect completed architecture (no more "coming soon" language).
+- README overhauled with three-backend architecture, environment variables table,
+  and use-case examples.
+- Credo strict: 0 issues. Dialyzer: 0 errors.
 
 ## 0.1.0 (Phase 1)
 
@@ -51,39 +116,38 @@
 
 ## Phase History
 
-### Phase 2 — Pure Elixir Reference Backend
+### Phase 2 -- Pure Elixir Reference Backend
 
 - Correctness-first pure Elixir backend using `%{{row, col} => value}` maps.
 - `mxm`, `mxv`, `vxm`, `ewise_add`, `ewise_mult`, `reduce`, `transpose`.
 - Initial semiring set: `plus_times`, `lor_land`, `plus_min`.
 
-### Phase 3 — SuiteSparse Native Backend Foundation
+### Phase 3 -- SuiteSparse Native Backend Foundation
 
 - SuiteSparse:GraphBLAS native backend via Zigler.
 - NIF resource lifecycle with dirty CPU schedulers.
 - Error mapping from GrB error codes to Elixir errors.
 
-### Phase 4 — Core Sparse Operations Parity and Semantic Validation
+### Phase 4 -- Core Sparse Operations Parity and Semantic Validation
 
 - Full parity between Elixir and SuiteSparse backends.
 - Shared test suites with property-based testing (StreamData).
 - Extended semiring set to 10 built-in semirings.
 - JIT disabled for reproducibility.
 
-### Phase 5 — Masks, Descriptors, and API Honing
+### Phase 5 -- Masks, Descriptors, and API Honing
 
 - Structural and complement masks for all compute operations.
 - Descriptor control: input transpose, output replacement.
 - `set`, `extract`, `dup` for both Matrix and Vector.
 - Masked mxm/vxm benchmarks.
 
-### Phase 6 — Graph Algorithms, Knowledge Graphs, and Query Foundations
+### Phase 6 -- Graph Algorithms, Knowledge Graphs, and Query Foundations
 
 - 7 graph algorithms: bfs_reach, bfs_levels, sssp, triangle_count,
   connected_components, degree, pagerank.
-- `GraphBLAS.Relation` module for knowledge graph modeling.
+- `GraphBLAS.Relation` module for knowledge graph modelling.
 - `traverse/4` for multi-hop traversal across predicates.
 - `closure/4` for transitive closure.
 - `fixed_point/3` generic iteration primitive.
 - Added `:min_plus` and `:min_plus_fp64` semirings.
-- 470 tests passing, 88% coverage.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ An Elixir library for sparse linear algebra and graph computation, inspired by t
 [![HexDocs.pm](https://img.shields.io/badge/hex-docs-lightgreen.svg)](https://hexdocs.pm/ex_graphblas)
 [![Precompiled NIFs](https://github.com/thanos/ex_graphblas/actions/workflows/precompiled-nifs.yml/badge.svg)](https://github.com/thanos/ex_graphblas/actions/workflows/precompiled-nifs.yml)
 
-GraphBLAS provides idiomatic Elixir data structures at the boundary while delegating computation to swappable backends. The same code runs on a pure Elixir reference backend for development and testing, and on SuiteSparse:GraphBLAS via Zigler NIFs for native performance in production.
+GraphBLAS provides idiomatic Elixir data structures at the boundary while delegating computation to swappable backends. The same code runs on a pure Elixir reference backend for development and testing, on SuiteSparse:GraphBLAS via Zigler NIFs for native performance in production, and on a minimal ZigStub backend for CI verification without native dependencies.
 
 ## Contents
 
@@ -43,6 +43,7 @@ GraphBLAS.Matrix / GraphBLAS.Vector    -- public API (backend-neutral)
 GraphBLAS.Backend                      -- behaviour defining the computation contract
 GraphBLAS.Backend.Elixir               -- pure Elixir reference implementation
 GraphBLAS.Backend.SuiteSparse          -- SuiteSparse:GraphBLAS via Zigler NIFs
+GraphBLAS.Backend.ZigStub              -- minimal Zig NIF backend for CI verification
 ```
 
 Each `%Matrix{}` and `%Vector{}` struct carries a `backend` field, so inspection and mutation operations dispatch to the correct backend automatically.
@@ -224,6 +225,14 @@ Or in your `config/config.exs`:
     config :ex_graphblas, suitesparse_include_path: "/opt/homebrew/include/suitesparse"
 
 See `guides/installation_guide.md` for platform-specific instructions.
+
+### Environment variables
+
+| Variable | Purpose |
+|----------|---------|
+| `SUITESPARSE_INCLUDE_PATH` | Path to SuiteSparse headers (default: `/opt/homebrew/include/suitesparse`) |
+| `EX_GRAPHBLAS_BUILD` | Set to `1` to force building NIFs from source instead of using precompiled binaries |
+| `EX_GRAPHBLAS_COMPILE_NATIVE` | Set to `1` to include the SuiteSparse backend in test compilation |
 
 ## Guides
 

--- a/bench/core_ops_benchmarks.exs
+++ b/bench/core_ops_benchmarks.exs
@@ -167,8 +167,15 @@ Benchee.run(
 
 # --- mxv ---
 
-{:ok, v100_elixir} = Vector.from_entries(100, Enum.map(0..99, fn i -> {i, :rand.uniform(10)} end), :int64, backend: RefBackend)
-{:ok, v100_ss} = Vector.from_entries(100, Enum.map(0..99, fn i -> {i, :rand.uniform(10)} end), :int64, backend: SuiteSparse)
+{:ok, v100_elixir} =
+  Vector.from_entries(100, Enum.map(0..99, fn i -> {i, :rand.uniform(10)} end), :int64,
+    backend: RefBackend
+  )
+
+{:ok, v100_ss} =
+  Vector.from_entries(100, Enum.map(0..99, fn i -> {i, :rand.uniform(10)} end), :int64,
+    backend: SuiteSparse
+  )
 
 IO.puts("\n=== mxv (100x100 * 100, :plus_times) ===")
 

--- a/bench/phase5_benchmarks.exs
+++ b/bench/phase5_benchmarks.exs
@@ -39,8 +39,18 @@ ncols_a = 80
 nrows_b = 50
 ncols_b = 40
 
-a_entries = for r <- 0..(nrows_a - 1), c <- 0..(ncols_a - 1), :rand.uniform() < 0.05, do: {r, c, :rand.uniform(50)}
-b_entries = for r <- 0..(nrows_b - 1), c <- 0..(ncols_b - 1), :rand.uniform() < 0.05, do: {r, c, :rand.uniform(50)}
+a_entries =
+  for r <- 0..(nrows_a - 1),
+      c <- 0..(ncols_a - 1),
+      :rand.uniform() < 0.05,
+      do: {r, c, :rand.uniform(50)}
+
+b_entries =
+  for r <- 0..(nrows_b - 1),
+      c <- 0..(ncols_b - 1),
+      :rand.uniform() < 0.05,
+      do: {r, c, :rand.uniform(50)}
+
 a_entries = if a_entries == [], do: [{0, 1, 1}], else: a_entries
 b_entries = if b_entries == [], do: [{1, 0, 1}], else: b_entries
 
@@ -113,7 +123,9 @@ Benchee.run(
 # 2. Descriptor inp0_transpose on mxm
 # =============================================================================
 
-IO.puts("\n=== Descriptor inp0_transpose on mxm (#{nrows_a}x#{ncols_a} * #{nrows_b}x#{ncols_b}) ===\n")
+IO.puts(
+  "\n=== Descriptor inp0_transpose on mxm (#{nrows_a}x#{ncols_a} * #{nrows_b}x#{ncols_b}) ===\n"
+)
 
 desc = Descriptor.new(inp0_transpose: :transpose)
 

--- a/bench/phase6_algorithms_benchmarks.exs
+++ b/bench/phase6_algorithms_benchmarks.exs
@@ -40,8 +40,11 @@ Benchee.run(
 size_levels = 200
 rand_entries = BenchData.random_graph(size_levels, 0.05)
 
-{:ok, ref_bfs_rand} = RefBackend.matrix_from_coo(size_levels, size_levels, rand_entries, :bool, [])
-{:ok, ss_bfs_rand} = SuiteSparse.matrix_from_coo(size_levels, size_levels, rand_entries, :bool, [])
+{:ok, ref_bfs_rand} =
+  RefBackend.matrix_from_coo(size_levels, size_levels, rand_entries, :bool, [])
+
+{:ok, ss_bfs_rand} =
+  SuiteSparse.matrix_from_coo(size_levels, size_levels, rand_entries, :bool, [])
 
 IO.puts("\n=== bfs_levels (random graph, #{size_levels} vertices, 5% density) ===\n")
 
@@ -113,7 +116,9 @@ cc_entries = BenchData.undirected_random_graph(size_cc, 0.05)
 {:ok, ref_cc} = RefBackend.matrix_from_coo(size_cc, size_cc, cc_entries, :bool, [])
 {:ok, ss_cc} = SuiteSparse.matrix_from_coo(size_cc, size_cc, cc_entries, :bool, [])
 
-IO.puts("\n=== connected_components (undirected random graph, #{size_cc} vertices, 5% density) ===\n")
+IO.puts(
+  "\n=== connected_components (undirected random graph, #{size_cc} vertices, 5% density) ===\n"
+)
 
 Benchee.run(
   %{
@@ -293,4 +298,6 @@ SuiteSparse.matrix_free(ss_pr)
 SuiteSparse.matrix_free(ss_fp)
 GraphBLAS.Native.grb_finalize()
 
-IO.puts("\n=====================================\nPhase 6 algorithm benchmarks complete.\n=====================================\n")
+IO.puts(
+  "\n=====================================\nPhase 6 algorithm benchmarks complete.\n=====================================\n"
+)

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,4 +1,11 @@
 import Config
 
+# The default backend is pure Elixir -- no native dependencies required.
+# To use the SuiteSparse native backend in production, set:
+#
+#   config :ex_graphblas, default_backend: GraphBLAS.Backend.SuiteSparse
+#
+# and ensure SuiteSparse:GraphBLAS >= 9.4.5 is installed. See the
+# installation guide for platform-specific instructions.
 config :ex_graphblas,
   default_backend: GraphBLAS.Backend.Elixir

--- a/guides/architecture_walkthrough.md
+++ b/guides/architecture_walkthrough.md
@@ -186,9 +186,9 @@ If calling code pattern-matched on the data field, it would break when switching
 
 **Rule**: Never access the `:data` field directly. Always use API functions.
 
-## Masks and descriptors (what's coming)
+## Masks and descriptors
 
-Masks and descriptors are defined in Phase 1 but not yet wired into operations. Here is a preview:
+Masks and descriptors are fully implemented and supported on all compute operations.
 
 ### Masks
 
@@ -196,9 +196,10 @@ Masks and descriptors are defined in Phase 1 but not yet wired into operations. 
 # A mask restricts which output positions are written
 mask = GraphBLAS.Mask.new(frontier)         # write only where frontier has stored entries
 cmask = GraphBLAS.Mask.complement(frontier)  # write only where frontier does NOT have stored entries
-```
 
-Masks will be passed as options: `GraphBLAS.Matrix.mxm(a, b, :plus_times, mask: mask)`
+# Pass as an option to any compute operation
+{:ok, result} = GraphBLAS.Matrix.mxm(a, b, :plus_times, mask: mask)
+```
 
 ### Descriptors
 
@@ -206,15 +207,17 @@ Masks will be passed as options: `GraphBLAS.Matrix.mxm(a, b, :plus_times, mask: 
 # A descriptor modifies how the operation interprets inputs and outputs
 desc = GraphBLAS.Descriptor.new(inp0_transpose: :transpose)
 # This tells mxm to treat A as if it were transposed, without creating A^T
+
+{:ok, result} = GraphBLAS.Matrix.mxm(a, b, :plus_times, descriptor: desc)
 ```
 
-Descriptors will be passed as: `GraphBLAS.Matrix.mxm(a, b, :plus_times, descriptor: desc)`
+See the [Masks and descriptors guide](masks_and_descriptors_guide.md) for full details.
 
-## Next steps
+## Completed phases
 
-- **Phase 2 (done)**: The Elixir reference backend now uses flat tuple-key maps and has semantic correctness tests. Dense conversion helpers (`Matrix.to_dense`, `Vector.to_list`) added.
-- **Phase 3**: SuiteSparse native backend via Zigler
-- **Phase 3**: More operations (additional semirings, assignment, extraction)
+- **Phase 1**: Core data structures, Backend behaviour, architecture
+- **Phase 2**: Elixir reference backend with flat tuple-key maps, semantic correctness tests, dense conversion helpers
+- **Phase 3**: SuiteSparse native backend via Zigler, additional semirings, assignment, extraction
 - **Phase 4**: Full mask and descriptor support in compute operations
-- **Phase 5**: Graph algorithms built on the operations API (BFS, PageRank, triangle counting)
-- **Phase 6**: Nx integration (conversion helpers, reference adapter)
+- **Phase 5**: Graph algorithms (BFS, SSSP, triangle count, connected components, PageRank, degree)
+- **Phase 6**: Knowledge graph queries (`GraphBLAS.Relation`), transitive closure, fixed-point iteration

--- a/guides/installation_guide.md
+++ b/guides/installation_guide.md
@@ -38,7 +38,7 @@ The SuiteSparse backend provides high-performance sparse operations via the Suit
 brew install suite-sparse
 ```
 
-SuiteSparse headers install to `/opt/homebrew/include/suitesparse`. This is the default include path.
+On Apple Silicon Macs, SuiteSparse headers install to `/opt/homebrew/include/suitesparse` (the default include path). On Intel Macs, headers install to `/usr/local/include/suitesparse` -- set the `SUITESPARSE_INCLUDE_PATH` environment variable accordingly.
 
 ### Linux (Debian/Ubuntu)
 
@@ -179,7 +179,7 @@ mix compile --force
 Check the compilation output for Zig/C errors. Common causes:
 - SuiteSparse not installed
 - Wrong include path
-- Incompatible SuiteSparse version (requires >= 7.0)
+- Incompatible SuiteSparse version (requires >= 9.4.5)
 
 ### "function clause error" on Vector.nvals with SuiteSparse
 

--- a/guides/masks_and_descriptors_guide.md
+++ b/guides/masks_and_descriptors_guide.md
@@ -102,14 +102,7 @@ Masks and descriptors compose naturally:
 
 ### Replace output descriptor
 
-The `output: :replace` descriptor clears the output before writing. In the current API (which always creates fresh results), it is a no-op. It becomes meaningful when in-place operations are added:
-
-```elixir
-# Future: in-place mxm that replaces the contents of c
-# {:ok, c} = Matrix.mxm_into(c, a, b, :plus_times, descriptor: Descriptor.replace_output())
-```
-
-For now, use `Descriptor.replace_output()` to prepare for in-place operations.
+The `output: :replace` descriptor clears the output before writing. In v0.2.0, all operations create fresh results, so `output: :replace` has no observable effect. It is accepted and passed through to SuiteSparse (which does use it internally), but does not change behavior when called from the Elixir API. It is included for forward-compatibility with future in-place operations.
 
 ## Container manipulation
 

--- a/guides/native_backend_walkthrough.md
+++ b/guides/native_backend_walkthrough.md
@@ -31,9 +31,9 @@ This walkthrough explains exactly what happens at that boundary, why it is safe,
 {:ok, coo} = GraphBLAS.Matrix.to_coo(c)
 
 # IMPORTANT: Free SuiteSparse objects when done
-SuiteSparse.matrix_free(a)
-SuiteSparse.matrix_free(b)
-SuiteSparse.matrix_free(c)
+GraphBLAS.Backend.SuiteSparse.matrix_free(a)
+GraphBLAS.Backend.SuiteSparse.matrix_free(b)
+GraphBLAS.Backend.SuiteSparse.matrix_free(c)
 ```
 
 The API is identical to the Elixir backend. The `backend:` option selects which implementation runs. The result data structure has the same shape — only the `:data` field contents differ.
@@ -115,12 +115,12 @@ No data was copied. The matrix lives in SuiteSparse's memory. Elixir holds only 
 ### Creating a matrix
 
 ```elixir
-{:ok, m} = SuiteSparse.matrix_from_coo(3, 3, entries, :int64, [])
+{:ok, m} = GraphBLAS.Backend.SuiteSparse.matrix_from_coo(3, 3, entries, :int64, [])
 ```
 
 What happens:
 
-1. `Backend.SuiteSparse.matrix_from_coo/5` validates dimensions and type
+1. The SuiteSparse backend's `matrix_from_coo` validates dimensions and type
 2. Calls `Native.matrix_new(3, 3, 8)` — Zig creates `GrB_Matrix`, returns pointer as `usize`
 3. Calls `Native.matrix_build_int64(ptr, rows, cols, vals, length)` — Zig calls `GrB_Matrix_build_INT64`
 4. Returns `{:ok, %Matrix{shape: {3, 3}, type: :int64, data: %{ptr: 46128889856}}}`
@@ -128,8 +128,8 @@ What happens:
 ### Using a matrix
 
 ```elixir
-{:ok, nvals} = SuiteSparse.matrix_nvals(m)     # Fast, not dirty_cpu
-{:ok, coo} = SuiteSparse.matrix_to_coo(m)       # Requires data extraction, dirty_cpu
+{:ok, nvals} = GraphBLAS.Backend.SuiteSparse.matrix_nvals(m)     # Fast, not dirty_cpu
+{:ok, coo} = GraphBLAS.Backend.SuiteSparse.matrix_to_coo(m)       # Requires data extraction, dirty_cpu
 ```
 
 `nvals/1` calls `GrB_Matrix_nvals` — O(1), no dirty scheduler needed.
@@ -139,7 +139,7 @@ What happens:
 ### Destroying a matrix
 
 ```elixir
-SuiteSparse.matrix_free(m)
+GraphBLAS.Backend.SuiteSparse.matrix_free(m)
 ```
 
 Explicit. Required. The BEAM garbage collector does NOT free the underlying C memory because the pointer is stored as an integer, not as a managed resource.

--- a/guides/parity_testing_guide.md
+++ b/guides/parity_testing_guide.md
@@ -153,7 +153,7 @@ defmodule GraphBLAS.Backend.ParityTest do
 | Error paths | ~5 |
 | Semantic correctness | ~15 |
 
-### Total: ~175-200 new tests
+### Total: 350+ tests across all suites
 
 ## Debugging parity failures
 

--- a/lib/ex_graphblas/algorithm.ex
+++ b/lib/ex_graphblas/algorithm.ex
@@ -399,11 +399,21 @@ defmodule GraphBLAS.Algorithm do
   `max_iter` is reached. Returns `{:ok, final_value, info}` where
   info contains `%{iterations: n, converged: boolean}`.
 
+  ## Default convergence behavior
+
+  When no `:convergence_fn` is provided:
+
+  - **Matrices** -- exact comparison of sorted COO entries (ignores `:tol`)
+  - **Vectors with `tol > 0`** -- all entries differ by less than `:tol`
+  - **Vectors with `tol == 0`** -- exact comparison of sorted entries
+  - **Other values** -- never converges (always runs to `max_iter`)
+
   ## Options
 
   - `:max_iter` -- maximum iterations (default: 100)
-  - `:tol` -- convergence tolerance for fp64 (default: 1.0e-6)
-  - `:convergence_fn` -- custom convergence check `(old, new -> boolean)`
+  - `:tol` -- convergence tolerance for fp64 vectors (default: 1.0e-6)
+  - `:convergence_fn` -- custom convergence check `(old, new -> boolean)`, overrides the defaults above
+  - `:backend` -- override the default backend
   """
   @spec fixed_point(term(), (term() -> {:ok, term()} | {:error, Error.t()}), keyword()) ::
           {:ok, term(), map()} | {:error, Error.t()}

--- a/lib/ex_graphblas/algorithm.ex
+++ b/lib/ex_graphblas/algorithm.ex
@@ -145,6 +145,11 @@ defmodule GraphBLAS.Algorithm do
 
   The adjacency matrix must be fp64 with edge weights as entries.
   Uses the `:min_plus_fp64` semiring. Converges when distances stop changing.
+
+  Options:
+  - `:max_iter` -- maximum iterations (default: 100)
+  - `:infinity` -- sentinel value for unreachable vertices (default: 1.0e18)
+  - `:backend` -- override the default backend
   """
   @spec sssp(Matrix.t(), non_neg_integer(), keyword()) ::
           {:ok, Vector.t()} | {:error, Error.t()}
@@ -152,19 +157,20 @@ defmodule GraphBLAS.Algorithm do
     with :ok <- validate_source(source, n) do
       backend = Config.resolve_backend(opts)
       max_iter = Keyword.get(opts, :max_iter, @default_max_iter)
+      inf = Keyword.get(opts, :infinity, @sssp_inf)
 
-      entries = for i <- 0..(n - 1), do: {i, if(i == source, do: 0.0, else: @sssp_inf)}
+      entries = for i <- 0..(n - 1), do: {i, if(i == source, do: 0.0, else: inf)}
 
       with {:ok, dist} <- Vector.from_entries(n, entries, :fp64, backend: backend),
            {:ok, final} <- sssp_loop(adj, dist, 0, max_iter, backend) do
-        sssp_strip_inf(final, n, backend)
+        sssp_strip_inf(final, n, inf, backend)
       end
     end
   end
 
-  defp sssp_strip_inf(dist, n, backend) do
+  defp sssp_strip_inf(dist, n, inf, backend) do
     {:ok, entries} = Vector.to_entries(dist)
-    reachable = Enum.reject(entries, fn {_, v} -> v >= @sssp_inf end)
+    reachable = Enum.reject(entries, fn {_, v} -> v >= inf end)
     Vector.from_entries(n, reachable, :fp64, backend: backend)
   end
 
@@ -255,8 +261,7 @@ defmodule GraphBLAS.Algorithm do
   end
 
   defp cc_expand_component(adj, component, unvisited, backend) do
-    {:ok, unvisited_entries} = Vector.to_entries(unvisited)
-    {v, _} = hd(unvisited_entries)
+    {:ok, [{v, _} | _]} = Vector.to_entries(unvisited)
 
     with {:ok, visited} <- bfs_reach(adj, v, backend: backend),
          {:ok, comp_val} <- Vector.extract(component, v),

--- a/lib/ex_graphblas/backend/zig_stub.ex
+++ b/lib/ex_graphblas/backend/zig_stub.ex
@@ -76,7 +76,7 @@ defmodule GraphBLAS.Backend.ZigStub do
   #############################################################################
 
   @impl GraphBLAS.Backend
-  def matrix_new(nrows, ncols, type, _opts) do
+  def matrix_new(nrows, ncols, type, _opts) when nrows >= 0 and ncols >= 0 do
     {:ok,
      %Matrix{
        shape: {nrows, ncols},
@@ -85,6 +85,12 @@ defmodule GraphBLAS.Backend.ZigStub do
        backend: __MODULE__
      }}
   end
+
+  def matrix_new(nrows, ncols, _type, _opts),
+    do:
+      Error.error(
+        {:invalid_argument, "dimensions must be non-negative, got {#{nrows}, #{ncols}}"}
+      )
 
   @impl GraphBLAS.Backend
   def matrix_nvals(%Matrix{data: %{entries: entries}}) do
@@ -131,7 +137,7 @@ defmodule GraphBLAS.Backend.ZigStub do
   #############################################################################
 
   @impl GraphBLAS.Backend
-  def vector_new(size, type, _opts) do
+  def vector_new(size, type, _opts) when size >= 0 do
     {:ok,
      %Vector{
        size: size,
@@ -140,6 +146,9 @@ defmodule GraphBLAS.Backend.ZigStub do
        backend: __MODULE__
      }}
   end
+
+  def vector_new(size, _type, _opts),
+    do: Error.error({:invalid_argument, "vector size must be non-negative, got #{size}"})
 
   @impl GraphBLAS.Backend
   def vector_nvals(%Vector{data: %{entries: entries}}) do

--- a/lib/ex_graphblas/binary_op.ex
+++ b/lib/ex_graphblas/binary_op.ex
@@ -33,6 +33,8 @@ defmodule GraphBLAS.BinaryOp do
 
   Prefer using built-in operators by atom name when possible.
   Custom operators are for cases where the built-in set does not suffice.
+
+  Raises `KeyError` if `:name`, `:function`, or `:type` is missing from `opts`.
   """
   @spec new(keyword()) :: t()
   def new(opts) do
@@ -57,6 +59,8 @@ defmodule GraphBLAS.BinaryOp do
 
   @doc """
   Returns the function implementation for a built-in binary operator name.
+
+  Raises `ArgumentError` if `name` is not a known built-in operator.
   """
   @spec fn_for(atom()) :: (term(), term() -> term())
   def fn_for(:plus), do: &Kernel.+/2

--- a/lib/ex_graphblas/monoid.ex
+++ b/lib/ex_graphblas/monoid.ex
@@ -45,6 +45,8 @@ defmodule GraphBLAS.Monoid do
   Creates a custom monoid struct.
 
   Prefer using built-in monoids by atom name when possible.
+
+  Raises `KeyError` if `:name`, `:operator`, `:identity`, or `:type` is missing from `opts`.
   """
   @spec new(keyword()) :: t()
   def new(opts) do

--- a/lib/ex_graphblas/monoid.ex
+++ b/lib/ex_graphblas/monoid.ex
@@ -41,6 +41,9 @@ defmodule GraphBLAS.Monoid do
   @enforce_keys [:name, :operator, :identity, :type]
   defstruct [:name, :operator, :identity, :type]
 
+  @int64_max 9_223_372_036_854_775_807
+  @int64_min -9_223_372_036_854_775_808
+
   @doc """
   Creates a custom monoid struct.
 
@@ -97,7 +100,7 @@ defmodule GraphBLAS.Monoid do
       new(
         name: :min,
         operator: :min,
-        identity: max_int(GraphBLAS.Scalar.new(:int64, 0), :int64),
+        identity: @int64_max,
         type: :int64
       )
 
@@ -109,7 +112,7 @@ defmodule GraphBLAS.Monoid do
       new(
         name: :max,
         operator: :max,
-        identity: min_int(GraphBLAS.Scalar.new(:int64, 0), :int64),
+        identity: @int64_min,
         type: :int64
       )
 
@@ -120,9 +123,6 @@ defmodule GraphBLAS.Monoid do
   def builtin(:lor), do: new(name: :lor, operator: :lor, identity: false, type: :bool)
   def builtin(:lxor), do: new(name: :lxor, operator: :lxor, identity: false, type: :bool)
   def builtin(_), do: nil
-
-  defp max_int(_, :int64), do: 9_223_372_036_854_775_807
-  defp min_int(_, :int64), do: -9_223_372_036_854_775_808
 
   @doc """
   Returns the list of all built-in monoid name atoms.

--- a/lib/ex_graphblas/relation.ex
+++ b/lib/ex_graphblas/relation.ex
@@ -245,6 +245,10 @@ defmodule GraphBLAS.Relation do
   - `:lor_land` -- reachability closure (who can eventually reach whom?)
   - `:plus_min` -- shortest path closure
   - `:plus_times` -- all-paths counting closure
+
+  Options:
+  - `:max_iter` -- maximum iterations before returning (default: 100)
+  - `:backend` -- override the default backend
   """
   @spec closure(t(), atom(), atom() | GraphBLAS.Semiring.t(), keyword()) ::
           {:ok, Matrix.t()} | {:error, Error.t()}
@@ -253,8 +257,10 @@ defmodule GraphBLAS.Relation do
       {:ok, matrix} ->
         backend = Config.resolve_backend(opts)
 
+        max_iter = Keyword.get(opts, :max_iter, 100)
+
         with {:ok, sr} <- GraphBLAS.Semiring.resolve(semiring) do
-          closure_loop(matrix, matrix, sr, backend, 0)
+          closure_loop(matrix, matrix, sr, backend, 0, max_iter)
         end
 
       :error ->
@@ -262,9 +268,10 @@ defmodule GraphBLAS.Relation do
     end
   end
 
-  defp closure_loop(_a, p, _semiring, _backend, iter) when iter >= 100, do: {:ok, p}
+  defp closure_loop(_a, p, _semiring, _backend, iter, max_iter) when iter >= max_iter,
+    do: {:ok, p}
 
-  defp closure_loop(a, p, semiring, backend, iter) do
+  defp closure_loop(a, p, semiring, backend, iter, max_iter) do
     add_monoid = semiring.add
 
     with {:ok, new_paths} <- Matrix.mxm(p, a, semiring.name, backend: backend),
@@ -278,7 +285,7 @@ defmodule GraphBLAS.Relation do
         {:ok, p_new}
       else
         maybe_free_intermediate(p, backend)
-        closure_loop(a, p_new, semiring, backend, iter + 1)
+        closure_loop(a, p_new, semiring, backend, iter + 1, max_iter)
       end
     end
   end

--- a/lib/ex_graphblas/semiring.ex
+++ b/lib/ex_graphblas/semiring.ex
@@ -68,6 +68,8 @@ defmodule GraphBLAS.Semiring do
   - `:add_identity` -- the 𝟎 identity element for the add operator
   - `:multiply_identity` -- the 𝟏 identity element for the multiply operator
   - `:type` -- the scalar type this semiring operates on
+
+  Raises `KeyError` if any required key is missing.
   """
   @spec new(keyword()) :: t()
   def new(opts) do

--- a/lib/ex_graphblas/unary_op.ex
+++ b/lib/ex_graphblas/unary_op.ex
@@ -36,6 +36,8 @@ defmodule GraphBLAS.UnaryOp do
 
   @doc """
   Creates a custom unary operator struct.
+
+  Raises `KeyError` if `:name`, `:function`, or `:type` is missing from `opts`.
   """
   @spec new(keyword()) :: t()
   def new(opts) do
@@ -58,6 +60,8 @@ defmodule GraphBLAS.UnaryOp do
 
   @doc """
   Returns the function implementation for a built-in unary operator name.
+
+  Raises `ArgumentError` if `name` is not a known built-in operator.
   """
   @spec fn_for(atom()) :: (term() -> term())
   def fn_for(:identity), do: &Function.identity/1

--- a/lib/graph_blas/application.ex
+++ b/lib/graph_blas/application.ex
@@ -2,6 +2,7 @@ defmodule GraphBLAS.Application do
   @moduledoc false
 
   use Application
+  require Logger
 
   @native_mod GraphBLAS.Native.SuiteSparse
 
@@ -12,7 +13,7 @@ defmodule GraphBLAS.Application do
         try do
           mod.grb_init()
         rescue
-          _ -> :ok
+          e -> Logger.debug("SuiteSparse grb_init failed: #{inspect(e)}")
         end
 
       {:error, _} ->
@@ -31,7 +32,7 @@ defmodule GraphBLAS.Application do
         try do
           mod.grb_finalize()
         rescue
-          _ -> :ok
+          e -> Logger.debug("SuiteSparse grb_finalize failed: #{inspect(e)}")
         end
 
       {:error, _} ->

--- a/mix.exs
+++ b/mix.exs
@@ -17,7 +17,7 @@ defmodule GraphBLAS.MixProject do
     [
       app: :ex_graphblas,
       version: @version,
-      elixir: "~> 1.17",
+      elixir: "~> 1.18",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       aliases: [

--- a/mix.exs
+++ b/mix.exs
@@ -35,8 +35,10 @@ defmodule GraphBLAS.MixProject do
         "coveralls.post": :test,
         "coveralls.html": :test
       ],
+      source_url: @source_url,
       docs: [
-        # Hex.pm landing page: /doc/readme.html
+        source_url: @source_url,
+        source_ref: "v#{@version}",
         main: "readme",
         extras: [
           {"README.md", [title: "GraphBLAS"]},
@@ -73,7 +75,7 @@ defmodule GraphBLAS.MixProject do
       {:ex_doc, "~> 0.34", only: :dev, runtime: false},
       {:benchee, "~> 1.3", only: :dev, runtime: false},
       {:credo, "~> 1.7", only: [:dev, :test], runtime: false},
-      {:excoveralls, "~> 0.18", only: :test},
+      {:excoveralls, "~> 0.18", only: :test, runtime: false},
       {:stream_data, "~> 1.1", only: [:dev, :test]},
       {:dialyxir, "~> 1.4", only: [:dev, :test], runtime: false},
       {:mix_audit, "~> 2.1", only: [:dev, :test], runtime: false}
@@ -91,7 +93,7 @@ defmodule GraphBLAS.MixProject do
   end
 
   defp elixirc_paths(:dev), do: ["lib", "native", "bench"]
-  defp elixirc_paths(_), do: ["lib", "native"]
+  defp elixirc_paths(_), do: ["lib"]
 
   defp description do
     "Sparse linear algebra and graph computation in Elixir, inspired by the GraphBLAS standard."
@@ -102,8 +104,8 @@ defmodule GraphBLAS.MixProject do
       licenses: ["Apache-2.0"],
       maintainers: ["Thanos Vassilakis"],
       links: %{"GitHub" => @source_url},
-      # files: ~w(lib .formatter.exs mix.exs README.md LICENSE CHANGELOG.md),
-      exclude_patterns: ["bench", "docs", "guides", "plans", "prompts"]
+      files: ~w(lib native priv/native .formatter.exs mix.exs README.md LICENSE CHANGELOG.md),
+      exclude_patterns: ["bench", "docs", "plans", "prompts"]
     ]
   end
 

--- a/native/suite_sparse.ex
+++ b/native/suite_sparse.ex
@@ -16,6 +16,17 @@ defmodule GraphBLAS.Native.SuiteSparse do
   from source. Set EX_GRAPHBLAS_BUILD=1 to force local compilation
   (requires Zig and SuiteSparse:GraphBLAS installed).
 
+  ## Include path
+
+  The default include path is `/opt/homebrew/include/suitesparse` (macOS
+  Apple Silicon). Override via the `SUITESPARSE_INCLUDE_PATH` environment
+  variable or the `:suitesparse_include_path` application config. Common
+  values:
+
+  - macOS Apple Silicon: `/opt/homebrew/include/suitesparse`
+  - macOS Intel: `/usr/local/include/suitesparse`
+  - Linux (Debian/Ubuntu): `/usr/include/suitesparse`
+
   ## Pointer lifecycle
 
   C pointers (GrB_Matrix, GrB_Vector) are stored as usize integers

--- a/native/suite_sparse.ex
+++ b/native/suite_sparse.ex
@@ -52,6 +52,14 @@ defmodule GraphBLAS.Native.SuiteSparse do
     base_url: "https://github.com/thanos/ex_graphblas/releases/download/v#{version}",
     version: version,
     force_build: System.get_env("EX_GRAPHBLAS_BUILD") in ["1", "true"],
+    targets: ~w(
+      aarch64-linux-gnu
+      aarch64-linux-musl
+      aarch64-macos-none
+      x86_64-linux-gnu
+      x86_64-linux-musl
+      x86_64-macos-none
+    ),
     zig_code_path: "../priv/native/suite_sparse/graphblas.zig",
     c: [
       link_lib: {:system, "graphblas"},

--- a/native/suite_sparse_backend.ex
+++ b/native/suite_sparse_backend.ex
@@ -119,8 +119,8 @@ defmodule GraphBLAS.Backend.SuiteSparse do
       semiring_code = semiring_to_code(sr)
 
       desc = Keyword.get(opts, :descriptor)
-      {a_ptr, _a} = maybe_transpose_inp0(a, desc)
-      {b_ptr, _b} = maybe_transpose_inp1(b, desc)
+      {a_ptr, a_transposed} = maybe_transpose_inp0(a, desc)
+      {b_ptr, b_transposed} = maybe_transpose_inp1(b, desc)
 
       mask_ptr = extract_mask_ptr(opts)
       mask_comp = mask_is_complement?(opts)
@@ -138,6 +138,9 @@ defmodule GraphBLAS.Backend.SuiteSparse do
         e ->
           cleanup_descriptor(desc_ptr)
           Error.error({:backend_error, __MODULE__, e})
+      after
+        maybe_free_transposed(a_ptr, a_transposed)
+        maybe_free_transposed(b_ptr, b_transposed)
       end
     end
   end
@@ -148,7 +151,7 @@ defmodule GraphBLAS.Backend.SuiteSparse do
       semiring_code = semiring_to_code(sr)
 
       desc = Keyword.get(opts, :descriptor)
-      {m_ptr, _matrix} = maybe_transpose_inp0(matrix, desc)
+      {m_ptr, m_transposed} = maybe_transpose_inp0(matrix, desc)
 
       mask_ptr = extract_mask_ptr(opts)
       mask_comp = mask_is_complement?(opts)
@@ -163,6 +166,8 @@ defmodule GraphBLAS.Backend.SuiteSparse do
         e ->
           cleanup_descriptor(desc_ptr)
           Error.error({:backend_error, __MODULE__, e})
+      after
+        maybe_free_transposed(m_ptr, m_transposed)
       end
     end
   end
@@ -407,7 +412,7 @@ defmodule GraphBLAS.Backend.SuiteSparse do
       semiring_code = semiring_to_code(sr)
 
       desc = Keyword.get(opts, :descriptor)
-      {m_ptr, _matrix} = maybe_transpose_inp1(matrix, desc)
+      {m_ptr, m_transposed} = maybe_transpose_inp1(matrix, desc)
 
       mask_ptr = extract_mask_ptr(opts)
       mask_comp = mask_is_complement?(opts)
@@ -422,6 +427,8 @@ defmodule GraphBLAS.Backend.SuiteSparse do
         e ->
           cleanup_descriptor(desc_ptr)
           Error.error({:backend_error, __MODULE__, e})
+      after
+        maybe_free_transposed(m_ptr, m_transposed)
       end
     end
   end
@@ -668,33 +675,33 @@ defmodule GraphBLAS.Backend.SuiteSparse do
   defp validate_index(idx, max) when is_integer(idx) and idx >= 0 and idx < max, do: :ok
   defp validate_index(idx, max), do: Error.error({:index_out_of_bounds, idx, :index, max})
 
+  # Returns {ptr, transposed?} where transposed? indicates the ptr must be freed by caller.
   defp maybe_transpose_inp0(%Matrix{data: %{ptr: ptr}} = m, desc) do
     if is_struct(desc, GraphBLAS.Descriptor) and desc.inp0_transpose == :transpose do
       case matrix_transpose(m, []) do
-        {:ok, %Matrix{data: %{ptr: t_ptr}} = t} ->
-          {t_ptr, t}
-
-        {:error, _} = err ->
-          err
+        {:ok, %Matrix{data: %{ptr: t_ptr}}} -> {t_ptr, true}
+        {:error, _} = err -> err
       end
     else
-      {ptr, m}
+      {ptr, false}
     end
   end
 
   defp maybe_transpose_inp1(%Matrix{data: %{ptr: ptr}} = m, desc) do
     if is_struct(desc, GraphBLAS.Descriptor) and desc.inp1_transpose == :transpose do
       case matrix_transpose(m, []) do
-        {:ok, %Matrix{data: %{ptr: t_ptr}} = t} ->
-          {t_ptr, t}
-
-        {:error, _} = err ->
-          err
+        {:ok, %Matrix{data: %{ptr: t_ptr}}} -> {t_ptr, true}
+        {:error, _} = err -> err
       end
     else
-      {ptr, m}
+      {ptr, false}
     end
   end
+
+  defp maybe_free_transposed(ptr, true),
+    do: GraphBLAS.Native.SuiteSparse.matrix_free(ptr)
+
+  defp maybe_free_transposed(_ptr, false), do: :ok
 
   defp extract_mask_ptr(opts) do
     case Keyword.get(opts, :mask) do

--- a/native/suite_sparse_backend.ex
+++ b/native/suite_sparse_backend.ex
@@ -127,7 +127,9 @@ defmodule GraphBLAS.Backend.SuiteSparse do
       desc_ptr = build_descriptor_ptr(opts, mask_comp, skip_transpose: true)
 
       try do
-        ptr = GraphBLAS.Native.SuiteSparse.matrix_mxm(a_ptr, b_ptr, semiring_code, mask_ptr, desc_ptr)
+        ptr =
+          GraphBLAS.Native.SuiteSparse.matrix_mxm(a_ptr, b_ptr, semiring_code, mask_ptr, desc_ptr)
+
         cleanup_descriptor(desc_ptr)
         nrows = GraphBLAS.Native.SuiteSparse.matrix_nrows(ptr)
         ncols = GraphBLAS.Native.SuiteSparse.matrix_ncols(ptr)
@@ -158,7 +160,9 @@ defmodule GraphBLAS.Backend.SuiteSparse do
       desc_ptr = build_descriptor_ptr(opts, mask_comp, skip_transpose: true)
 
       try do
-        ptr = GraphBLAS.Native.SuiteSparse.matrix_mxv(m_ptr, v_ptr, semiring_code, mask_ptr, desc_ptr)
+        ptr =
+          GraphBLAS.Native.SuiteSparse.matrix_mxv(m_ptr, v_ptr, semiring_code, mask_ptr, desc_ptr)
+
         cleanup_descriptor(desc_ptr)
         size = GraphBLAS.Native.SuiteSparse.vector_size(ptr)
         {:ok, %Vector{size: size, type: sr.type, backend: __MODULE__, data: %{ptr: ptr}}}
@@ -186,7 +190,15 @@ defmodule GraphBLAS.Backend.SuiteSparse do
       desc_ptr = build_descriptor_ptr(opts, mask_comp)
 
       try do
-        ptr = GraphBLAS.Native.SuiteSparse.matrix_ewise_add(a_ptr, b_ptr, monoid_code, mask_ptr, desc_ptr)
+        ptr =
+          GraphBLAS.Native.SuiteSparse.matrix_ewise_add(
+            a_ptr,
+            b_ptr,
+            monoid_code,
+            mask_ptr,
+            desc_ptr
+          )
+
         cleanup_descriptor(desc_ptr)
         {:ok, %Matrix{shape: a.shape, type: type, backend: __MODULE__, data: %{ptr: ptr}}}
       rescue
@@ -211,7 +223,15 @@ defmodule GraphBLAS.Backend.SuiteSparse do
       desc_ptr = build_descriptor_ptr(opts, mask_comp)
 
       try do
-        ptr = GraphBLAS.Native.SuiteSparse.matrix_ewise_mult(a_ptr, b_ptr, monoid_code, mask_ptr, desc_ptr)
+        ptr =
+          GraphBLAS.Native.SuiteSparse.matrix_ewise_mult(
+            a_ptr,
+            b_ptr,
+            monoid_code,
+            mask_ptr,
+            desc_ptr
+          )
+
         cleanup_descriptor(desc_ptr)
         {:ok, %Matrix{shape: a.shape, type: type, backend: __MODULE__, data: %{ptr: ptr}}}
       rescue
@@ -231,7 +251,14 @@ defmodule GraphBLAS.Backend.SuiteSparse do
       desc_ptr = build_descriptor_ptr(opts, mask_comp)
 
       try do
-        v_ptr = GraphBLAS.Native.SuiteSparse.matrix_reduce_to_vector(ptr, monoid_code, mask_ptr, desc_ptr)
+        v_ptr =
+          GraphBLAS.Native.SuiteSparse.matrix_reduce_to_vector(
+            ptr,
+            monoid_code,
+            mask_ptr,
+            desc_ptr
+          )
+
         cleanup_descriptor(desc_ptr)
         size = GraphBLAS.Native.SuiteSparse.vector_size(v_ptr)
         {:ok, %Vector{size: size, type: type, backend: __MODULE__, data: %{ptr: v_ptr}}}
@@ -419,7 +446,9 @@ defmodule GraphBLAS.Backend.SuiteSparse do
       desc_ptr = build_descriptor_ptr(opts, mask_comp, skip_transpose: true)
 
       try do
-        ptr = GraphBLAS.Native.SuiteSparse.vector_vxm(v_ptr, m_ptr, semiring_code, mask_ptr, desc_ptr)
+        ptr =
+          GraphBLAS.Native.SuiteSparse.vector_vxm(v_ptr, m_ptr, semiring_code, mask_ptr, desc_ptr)
+
         cleanup_descriptor(desc_ptr)
         size = GraphBLAS.Native.SuiteSparse.vector_size(ptr)
         {:ok, %Vector{size: size, type: sr.type, backend: __MODULE__, data: %{ptr: ptr}}}
@@ -447,7 +476,15 @@ defmodule GraphBLAS.Backend.SuiteSparse do
       desc_ptr = build_descriptor_ptr(opts, mask_comp)
 
       try do
-        ptr = GraphBLAS.Native.SuiteSparse.vector_ewise_add(a_ptr, b_ptr, monoid_code, mask_ptr, desc_ptr)
+        ptr =
+          GraphBLAS.Native.SuiteSparse.vector_ewise_add(
+            a_ptr,
+            b_ptr,
+            monoid_code,
+            mask_ptr,
+            desc_ptr
+          )
+
         cleanup_descriptor(desc_ptr)
         {:ok, %Vector{size: size, type: type, backend: __MODULE__, data: %{ptr: ptr}}}
       rescue
@@ -472,7 +509,15 @@ defmodule GraphBLAS.Backend.SuiteSparse do
       desc_ptr = build_descriptor_ptr(opts, mask_comp)
 
       try do
-        ptr = GraphBLAS.Native.SuiteSparse.vector_ewise_mult(a_ptr, b_ptr, monoid_code, mask_ptr, desc_ptr)
+        ptr =
+          GraphBLAS.Native.SuiteSparse.vector_ewise_mult(
+            a_ptr,
+            b_ptr,
+            monoid_code,
+            mask_ptr,
+            desc_ptr
+          )
+
         cleanup_descriptor(desc_ptr)
         {:ok, %Vector{size: size, type: type, backend: __MODULE__, data: %{ptr: ptr}}}
       rescue
@@ -769,9 +814,14 @@ defmodule GraphBLAS.Backend.SuiteSparse do
 
     try do
       case type do
-        :int64 -> GraphBLAS.Native.SuiteSparse.matrix_build_int64(ptr, rows, cols, vals, length(entries))
-        :fp64 -> GraphBLAS.Native.SuiteSparse.matrix_build_fp64(ptr, rows, cols, vals, length(entries))
-        :bool -> GraphBLAS.Native.SuiteSparse.matrix_build_bool(ptr, rows, cols, vals, length(entries))
+        :int64 ->
+          GraphBLAS.Native.SuiteSparse.matrix_build_int64(ptr, rows, cols, vals, length(entries))
+
+        :fp64 ->
+          GraphBLAS.Native.SuiteSparse.matrix_build_fp64(ptr, rows, cols, vals, length(entries))
+
+        :bool ->
+          GraphBLAS.Native.SuiteSparse.matrix_build_bool(ptr, rows, cols, vals, length(entries))
       end
 
       {:ok, %Matrix{shape: {nrows, ncols}, type: type, backend: __MODULE__, data: %{ptr: ptr}}}
@@ -787,9 +837,14 @@ defmodule GraphBLAS.Backend.SuiteSparse do
 
     try do
       case type do
-        :int64 -> GraphBLAS.Native.SuiteSparse.vector_build_int64(ptr, indices, vals, length(entries))
-        :fp64 -> GraphBLAS.Native.SuiteSparse.vector_build_fp64(ptr, indices, vals, length(entries))
-        :bool -> GraphBLAS.Native.SuiteSparse.vector_build_bool(ptr, indices, vals, length(entries))
+        :int64 ->
+          GraphBLAS.Native.SuiteSparse.vector_build_int64(ptr, indices, vals, length(entries))
+
+        :fp64 ->
+          GraphBLAS.Native.SuiteSparse.vector_build_fp64(ptr, indices, vals, length(entries))
+
+        :bool ->
+          GraphBLAS.Native.SuiteSparse.vector_build_bool(ptr, indices, vals, length(entries))
       end
 
       {:ok, %Vector{size: size, type: type, backend: __MODULE__, data: %{ptr: ptr}}}

--- a/priv/native/suite_sparse/graphblas.zig
+++ b/priv/native/suite_sparse/graphblas.zig
@@ -353,18 +353,21 @@
   // =============================================================================
 
   pub fn matrix_build_int64(ptr: usize, rows: []u64, cols: []u64, vals: []i64, nvals: u64) !void {
+      if (nvals > rows.len or nvals > cols.len or nvals > vals.len) return error.invalid_index;
       const matrix = mat_from_ptr(ptr);
       const info = GrB_Matrix_build_INT64(matrix, rows.ptr, cols.ptr, vals.ptr, nvals, GrB_PLUS_INT64);
       try translate_info(info);
   }
 
   pub fn matrix_build_fp64(ptr: usize, rows: []u64, cols: []u64, vals: []f64, nvals: u64) !void {
+      if (nvals > rows.len or nvals > cols.len or nvals > vals.len) return error.invalid_index;
       const matrix = mat_from_ptr(ptr);
       const info = GrB_Matrix_build_FP64(matrix, rows.ptr, cols.ptr, vals.ptr, nvals, GrB_PLUS_FP64);
       try translate_info(info);
   }
 
   pub fn matrix_build_bool(ptr: usize, rows: []u64, cols: []u64, vals: []bool, nvals: u64) !void {
+      if (nvals > rows.len or nvals > cols.len or nvals > vals.len) return error.invalid_index;
       const matrix = mat_from_ptr(ptr);
       const info = GrB_Matrix_build_BOOL(matrix, rows.ptr, cols.ptr, vals.ptr, nvals, GxB_LOR_BOOL);
       try translate_info(info);
@@ -603,18 +606,21 @@
   // =============================================================================
 
   pub fn vector_build_int64(ptr: usize, indices: []u64, vals: []i64, nvals: u64) !void {
+      if (nvals > indices.len or nvals > vals.len) return error.invalid_index;
       const vector = vec_from_ptr(ptr);
       const info = GrB_Vector_build_INT64(vector, indices.ptr, vals.ptr, nvals, GrB_PLUS_INT64);
       try translate_info(info);
   }
 
   pub fn vector_build_fp64(ptr: usize, indices: []u64, vals: []f64, nvals: u64) !void {
+      if (nvals > indices.len or nvals > vals.len) return error.invalid_index;
       const vector = vec_from_ptr(ptr);
       const info = GrB_Vector_build_FP64(vector, indices.ptr, vals.ptr, nvals, GrB_PLUS_FP64);
       try translate_info(info);
   }
 
   pub fn vector_build_bool(ptr: usize, indices: []u64, vals: []bool, nvals: u64) !void {
+      if (nvals > indices.len or nvals > vals.len) return error.invalid_index;
       const vector = vec_from_ptr(ptr);
       const info = GrB_Vector_build_BOOL(vector, indices.ptr, vals.ptr, nvals, GxB_LOR_BOOL);
       try translate_info(info);

--- a/priv/native/suite_sparse/graphblas.zig
+++ b/priv/native/suite_sparse/graphblas.zig
@@ -226,16 +226,16 @@
   // Type / semiring / monoid resolution
   // =============================================================================
 
-  fn type_code_to_grb_type(code: u8) GrB_Type {
+  fn type_code_to_grb_type(code: u8) GraphBLASError!GrB_Type {
       return switch (code) {
           1 => GrB_BOOL,
           8 => GrB_INT64,
           11 => GrB_FP64,
-          else => GrB_INT64,
+          else => error.invalid_value,
       };
   }
 
-  fn semiring_from_code(code: u8) GrB_Semiring {
+  fn semiring_from_code(code: u8) GraphBLASError!GrB_Semiring {
       return switch (code) {
           1 => GrB_PLUS_TIMES_SEMIRING_INT64,
           2 => GrB_PLUS_TIMES_SEMIRING_FP64,
@@ -247,11 +247,11 @@
           8 => GxB_MAX_MIN_FP64,
           9 => GxB_LOR_LAND_BOOL,
           10 => GxB_LAND_LOR_BOOL,
-          else => GrB_PLUS_TIMES_SEMIRING_INT64,
+          else => error.invalid_value,
       };
   }
 
-  fn monoid_from_code(code: u8) GrB_Monoid {
+  fn monoid_from_code(code: u8) GraphBLASError!GrB_Monoid {
       return switch (code) {
           1 => GrB_PLUS_MONOID_INT64,
           2 => GrB_PLUS_MONOID_FP64,
@@ -264,7 +264,7 @@
           9 => GrB_LAND_MONOID_BOOL,
           10 => GrB_LOR_MONOID_BOOL,
           11 => GrB_LXOR_MONOID_BOOL,
-          else => GrB_PLUS_MONOID_INT64,
+          else => error.invalid_value,
       };
   }
 
@@ -295,11 +295,11 @@
       // Disable SuiteSparse JIT compiler — pre-compiled kernels suffice
       // and JIT fails on some semirings (plus_min, etc.) returning
       // GxB_JIT_ERROR (-7001) which causes dirty_cpu NIFs to hang.
-      _ = GxB_Global_Option_set_INT32(GxB_JIT_C_CONTROL, GxB_JIT_OFF);
+      try translate_info(GxB_Global_Option_set_INT32(GxB_JIT_C_CONTROL, GxB_JIT_OFF));
   }
 
-  pub fn grb_finalize() void {
-      _ = GrB_finalize();
+  pub fn grb_finalize() !void {
+      try translate_info(GrB_finalize());
   }
 
   // =============================================================================
@@ -308,7 +308,7 @@
 
   pub fn matrix_new(nrows: u64, ncols: u64, type_code: u8) !usize {
       var matrix: GrB_Matrix = null;
-      const grb_type = type_code_to_grb_type(type_code);
+      const grb_type = try type_code_to_grb_type(type_code);
       const info = GrB_Matrix_new(&matrix, grb_type, nrows, ncols);
       try translate_info(info);
       return mat_to_ptr(matrix);
@@ -432,15 +432,15 @@
   pub fn matrix_mxm(a_ptr: usize, b_ptr: usize, semiring_code: u8, mask_ptr: usize, desc_ptr: usize) !usize {
       const a = mat_from_ptr(a_ptr);
       const b = mat_from_ptr(b_ptr);
-      const semiring = semiring_from_code(semiring_code);
+      const semiring = try semiring_from_code(semiring_code);
       const mask = mask_mat_from_ptr(mask_ptr);
       const desc = desc_from_ptr(desc_ptr);
       var nrows_a: u64 = undefined;
       var ncols_b: u64 = undefined;
-      _ = GrB_Matrix_nrows(&nrows_a, a);
-      _ = GrB_Matrix_ncols(&ncols_b, b);
+      try translate_info(GrB_Matrix_nrows(&nrows_a, a));
+      try translate_info(GrB_Matrix_ncols(&ncols_b, b));
       var a_type: GrB_Type = null;
-      _ = GxB_Matrix_type(&a_type, a);
+      try translate_info(GxB_Matrix_type(&a_type, a));
       var result: GrB_Matrix = null;
       const info_new = GrB_Matrix_new(&result, a_type, nrows_a, ncols_b);
       try translate_info(info_new);
@@ -455,13 +455,13 @@
   pub fn matrix_mxv(matrix_ptr: usize, vector_ptr: usize, semiring_code: u8, mask_ptr: usize, desc_ptr: usize) !usize {
       const matrix = mat_from_ptr(matrix_ptr);
       const vector = vec_from_ptr(vector_ptr);
-      const semiring = semiring_from_code(semiring_code);
+      const semiring = try semiring_from_code(semiring_code);
       const mask = mask_vec_from_ptr(mask_ptr);
       const desc = desc_from_ptr(desc_ptr);
       var nrows: u64 = undefined;
-      _ = GrB_Matrix_nrows(&nrows, matrix);
+      try translate_info(GrB_Matrix_nrows(&nrows, matrix));
       var mat_type: GrB_Type = null;
-      _ = GxB_Matrix_type(&mat_type, matrix);
+      try translate_info(GxB_Matrix_type(&mat_type, matrix));
       var result: GrB_Vector = null;
       const info_new = GrB_Vector_new(&result, mat_type, nrows);
       try translate_info(info_new);
@@ -479,10 +479,10 @@
       const desc = desc_from_ptr(desc_ptr);
       var nrows: u64 = undefined;
       var ncols: u64 = undefined;
-      _ = GrB_Matrix_nrows(&nrows, matrix);
-      _ = GrB_Matrix_ncols(&ncols, matrix);
+      try translate_info(GrB_Matrix_nrows(&nrows, matrix));
+      try translate_info(GrB_Matrix_ncols(&ncols, matrix));
       var mat_type: GrB_Type = null;
-      _ = GxB_Matrix_type(&mat_type, matrix);
+      try translate_info(GxB_Matrix_type(&mat_type, matrix));
       var result: GrB_Matrix = null;
       const info_new = GrB_Matrix_new(&result, mat_type, ncols, nrows);
       try translate_info(info_new);
@@ -497,15 +497,15 @@
   pub fn matrix_ewise_add(a_ptr: usize, b_ptr: usize, monoid_code: u8, mask_ptr: usize, desc_ptr: usize) !usize {
       const a = mat_from_ptr(a_ptr);
       const b = mat_from_ptr(b_ptr);
-      const monoid = monoid_from_code(monoid_code);
+      const monoid = try monoid_from_code(monoid_code);
       const mask = mask_mat_from_ptr(mask_ptr);
       const desc = desc_from_ptr(desc_ptr);
       var nrows: u64 = undefined;
       var ncols: u64 = undefined;
-      _ = GrB_Matrix_nrows(&nrows, a);
-      _ = GrB_Matrix_ncols(&ncols, a);
+      try translate_info(GrB_Matrix_nrows(&nrows, a));
+      try translate_info(GrB_Matrix_ncols(&ncols, a));
       var a_type: GrB_Type = null;
-      _ = GxB_Matrix_type(&a_type, a);
+      try translate_info(GxB_Matrix_type(&a_type, a));
       var result: GrB_Matrix = null;
       const info_new = GrB_Matrix_new(&result, a_type, nrows, ncols);
       try translate_info(info_new);
@@ -520,15 +520,15 @@
   pub fn matrix_ewise_mult(a_ptr: usize, b_ptr: usize, monoid_code: u8, mask_ptr: usize, desc_ptr: usize) !usize {
       const a = mat_from_ptr(a_ptr);
       const b = mat_from_ptr(b_ptr);
-      const monoid = monoid_from_code(monoid_code);
+      const monoid = try monoid_from_code(monoid_code);
       const mask = mask_mat_from_ptr(mask_ptr);
       const desc = desc_from_ptr(desc_ptr);
       var nrows: u64 = undefined;
       var ncols: u64 = undefined;
-      _ = GrB_Matrix_nrows(&nrows, a);
-      _ = GrB_Matrix_ncols(&ncols, a);
+      try translate_info(GrB_Matrix_nrows(&nrows, a));
+      try translate_info(GrB_Matrix_ncols(&ncols, a));
       var a_type: GrB_Type = null;
-      _ = GxB_Matrix_type(&a_type, a);
+      try translate_info(GxB_Matrix_type(&a_type, a));
       var result: GrB_Matrix = null;
       const info_new = GrB_Matrix_new(&result, a_type, nrows, ncols);
       try translate_info(info_new);
@@ -542,13 +542,13 @@
 
   pub fn matrix_reduce_to_vector(matrix_ptr: usize, monoid_code: u8, mask_ptr: usize, desc_ptr: usize) !usize {
       const matrix = mat_from_ptr(matrix_ptr);
-      const monoid = monoid_from_code(monoid_code);
+      const monoid = try monoid_from_code(monoid_code);
       const mask = mask_vec_from_ptr(mask_ptr);
       const desc = desc_from_ptr(desc_ptr);
       var nrows: u64 = undefined;
-      _ = GrB_Matrix_nrows(&nrows, matrix);
+      try translate_info(GrB_Matrix_nrows(&nrows, matrix));
       var mat_type: GrB_Type = null;
-      _ = GxB_Matrix_type(&mat_type, matrix);
+      try translate_info(GxB_Matrix_type(&mat_type, matrix));
       var result: GrB_Vector = null;
       const info_new = GrB_Vector_new(&result, mat_type, nrows);
       try translate_info(info_new);
@@ -566,7 +566,7 @@
 
   pub fn vector_new(size: u64, type_code: u8) !usize {
       var vector: GrB_Vector = null;
-      const grb_type = type_code_to_grb_type(type_code);
+      const grb_type = try type_code_to_grb_type(type_code);
       const info = GrB_Vector_new(&vector, grb_type, size);
       try translate_info(info);
       return vec_to_ptr(vector);
@@ -664,13 +664,13 @@
   pub fn vector_vxm(vector_ptr: usize, matrix_ptr: usize, semiring_code: u8, mask_ptr: usize, desc_ptr: usize) !usize {
       const vector = vec_from_ptr(vector_ptr);
       const matrix = mat_from_ptr(matrix_ptr);
-      const semiring = semiring_from_code(semiring_code);
+      const semiring = try semiring_from_code(semiring_code);
       const mask = mask_vec_from_ptr(mask_ptr);
       const desc = desc_from_ptr(desc_ptr);
       var ncols: u64 = undefined;
-      _ = GrB_Matrix_ncols(&ncols, matrix);
+      try translate_info(GrB_Matrix_ncols(&ncols, matrix));
       var vec_type: GrB_Type = null;
-      _ = GxB_Vector_type(&vec_type, vector);
+      try translate_info(GxB_Vector_type(&vec_type, vector));
       var result: GrB_Vector = null;
       const info_new = GrB_Vector_new(&result, vec_type, ncols);
       try translate_info(info_new);
@@ -685,13 +685,13 @@
   pub fn vector_ewise_add(a_ptr: usize, b_ptr: usize, monoid_code: u8, mask_ptr: usize, desc_ptr: usize) !usize {
       const a = vec_from_ptr(a_ptr);
       const b = vec_from_ptr(b_ptr);
-      const monoid = monoid_from_code(monoid_code);
+      const monoid = try monoid_from_code(monoid_code);
       const mask = mask_vec_from_ptr(mask_ptr);
       const desc = desc_from_ptr(desc_ptr);
       var size: u64 = undefined;
-      _ = GrB_Vector_size(&size, a);
+      try translate_info(GrB_Vector_size(&size, a));
       var a_type: GrB_Type = null;
-      _ = GxB_Vector_type(&a_type, a);
+      try translate_info(GxB_Vector_type(&a_type, a));
       var result: GrB_Vector = null;
       const info_new = GrB_Vector_new(&result, a_type, size);
       try translate_info(info_new);
@@ -706,13 +706,13 @@
   pub fn vector_ewise_mult(a_ptr: usize, b_ptr: usize, monoid_code: u8, mask_ptr: usize, desc_ptr: usize) !usize {
       const a = vec_from_ptr(a_ptr);
       const b = vec_from_ptr(b_ptr);
-      const monoid = monoid_from_code(monoid_code);
+      const monoid = try monoid_from_code(monoid_code);
       const mask = mask_vec_from_ptr(mask_ptr);
       const desc = desc_from_ptr(desc_ptr);
       var size: u64 = undefined;
-      _ = GrB_Vector_size(&size, a);
+      try translate_info(GrB_Vector_size(&size, a));
       var a_type: GrB_Type = null;
-      _ = GxB_Vector_type(&a_type, a);
+      try translate_info(GxB_Vector_type(&a_type, a));
       var result: GrB_Vector = null;
       const info_new = GrB_Vector_new(&result, a_type, size);
       try translate_info(info_new);
@@ -726,7 +726,7 @@
 
   pub fn vector_reduce_to_scalar_int64(ptr: usize, monoid_code: u8) !i64 {
       const vector = vec_from_ptr(ptr);
-      const monoid = monoid_from_code(monoid_code);
+      const monoid = try monoid_from_code(monoid_code);
       var result: i64 = 0;
       const info = GrB_Vector_reduce_INT64(&result, null, monoid, vector, null);
       try translate_info(info);
@@ -735,7 +735,7 @@
 
   pub fn vector_reduce_to_scalar_fp64(ptr: usize, monoid_code: u8) !f64 {
       const vector = vec_from_ptr(ptr);
-      const monoid = monoid_from_code(monoid_code);
+      const monoid = try monoid_from_code(monoid_code);
       var result: f64 = 0.0;
       const info = GrB_Vector_reduce_FP64(&result, null, monoid, vector, null);
       try translate_info(info);
@@ -744,7 +744,7 @@
 
   pub fn vector_reduce_to_scalar_bool(ptr: usize, monoid_code: u8) !bool {
       const vector = vec_from_ptr(ptr);
-      const monoid = monoid_from_code(monoid_code);
+      const monoid = try monoid_from_code(monoid_code);
       var result: bool = false;
       const info = GrB_Vector_reduce_BOOL(&result, null, monoid, vector, null);
       try translate_info(info);
@@ -817,23 +817,20 @@
       if (desc == null) return error.null_pointer;
 
       if (output_replace) {
-          _ = GrB_Descriptor_set_INT32(desc, GrB_OUTP, GrB_REPLACE);
+          try translate_info(GrB_Descriptor_set_INT32(desc, GrB_OUTP, GrB_REPLACE));
       }
       if (inp0_tran) {
-          _ = GrB_Descriptor_set_INT32(desc, GrB_INP0, GrB_TRAN);
+          try translate_info(GrB_Descriptor_set_INT32(desc, GrB_INP0, GrB_TRAN));
       }
       if (inp1_tran) {
-          _ = GrB_Descriptor_set_INT32(desc, GrB_INP1, GrB_TRAN);
+          try translate_info(GrB_Descriptor_set_INT32(desc, GrB_INP1, GrB_TRAN));
       }
-      // For mask field in custom descriptors, try setting each value
-      // If GrB_Descriptor_set_INT32 fails for some values, we proceed
-      // anyway since the default behavior may be acceptable
       if (mask_comp and mask_structural) {
-          _ = GrB_Descriptor_set_INT32(desc, GrB_MASK, GrB_COMP_STRUCTURE);
+          try translate_info(GrB_Descriptor_set_INT32(desc, GrB_MASK, GrB_COMP_STRUCTURE));
       } else if (mask_comp) {
-          _ = GrB_Descriptor_set_INT32(desc, GrB_MASK, GrB_COMP);
+          try translate_info(GrB_Descriptor_set_INT32(desc, GrB_MASK, GrB_COMP));
       } else if (mask_structural) {
-          _ = GrB_Descriptor_set_INT32(desc, GrB_MASK, GrB_STRUCTURE);
+          try translate_info(GrB_Descriptor_set_INT32(desc, GrB_MASK, GrB_STRUCTURE));
       }
 
       return @intFromPtr(desc);

--- a/test/ex_graphblas/algebraic_property_test.exs
+++ b/test/ex_graphblas/algebraic_property_test.exs
@@ -1,0 +1,149 @@
+defmodule GraphBLAS.AlgebraicPropertyTest do
+  use ExUnit.Case, async: true
+
+  alias GraphBLAS.Backend.Elixir, as: RefBackend
+
+  defp sort_coo(entries), do: Enum.sort(entries)
+
+  defp sort_vec(entries), do: Enum.sort(entries)
+
+  describe "commutativity of ewise_add" do
+    test "matrix: A + B == B + A for :plus monoid" do
+      {:ok, a} = RefBackend.matrix_from_coo(3, 3, [{0, 0, 1}, {1, 1, 2}], :int64, [])
+      {:ok, b} = RefBackend.matrix_from_coo(3, 3, [{0, 0, 3}, {2, 2, 4}], :int64, [])
+
+      {:ok, ab} = RefBackend.matrix_ewise_add(a, b, :plus, [])
+      {:ok, ba} = RefBackend.matrix_ewise_add(b, a, :plus, [])
+
+      {:ok, coo_ab} = RefBackend.matrix_to_coo(ab)
+      {:ok, coo_ba} = RefBackend.matrix_to_coo(ba)
+
+      assert sort_coo(coo_ab) == sort_coo(coo_ba)
+    end
+
+    test "vector: A + B == B + A for :plus monoid" do
+      {:ok, a} = RefBackend.vector_from_entries(4, [{0, 1}, {2, 3}], :int64, [])
+      {:ok, b} = RefBackend.vector_from_entries(4, [{0, 5}, {3, 7}], :int64, [])
+
+      {:ok, ab} = RefBackend.vector_ewise_add(a, b, :plus, [])
+      {:ok, ba} = RefBackend.vector_ewise_add(b, a, :plus, [])
+
+      {:ok, e_ab} = RefBackend.vector_to_entries(ab)
+      {:ok, e_ba} = RefBackend.vector_to_entries(ba)
+
+      assert sort_vec(e_ab) == sort_vec(e_ba)
+    end
+  end
+
+  describe "associativity of mxm" do
+    test "(A*B)*C == A*(B*C) for :plus_times" do
+      {:ok, a} = RefBackend.matrix_from_coo(2, 2, [{0, 0, 1}, {0, 1, 2}, {1, 0, 3}], :int64, [])
+      {:ok, b} = RefBackend.matrix_from_coo(2, 2, [{0, 0, 1}, {1, 1, 1}], :int64, [])
+      {:ok, c} = RefBackend.matrix_from_coo(2, 2, [{0, 0, 2}, {0, 1, 1}, {1, 0, 3}], :int64, [])
+
+      {:ok, ab} = RefBackend.matrix_mxm(a, b, :plus_times, [])
+      {:ok, ab_c} = RefBackend.matrix_mxm(ab, c, :plus_times, [])
+
+      {:ok, bc} = RefBackend.matrix_mxm(b, c, :plus_times, [])
+      {:ok, a_bc} = RefBackend.matrix_mxm(a, bc, :plus_times, [])
+
+      {:ok, coo_left} = RefBackend.matrix_to_coo(ab_c)
+      {:ok, coo_right} = RefBackend.matrix_to_coo(a_bc)
+
+      assert sort_coo(coo_left) == sort_coo(coo_right)
+    end
+  end
+
+  describe "transpose properties" do
+    test "(A^T)^T == A" do
+      entries = [{0, 1, 1}, {1, 0, 2}, {2, 1, 3}]
+      {:ok, a} = RefBackend.matrix_from_coo(3, 2, entries, :int64, [])
+
+      {:ok, at} = RefBackend.matrix_transpose(a, [])
+      {:ok, att} = RefBackend.matrix_transpose(at, [])
+
+      {:ok, coo_a} = RefBackend.matrix_to_coo(a)
+      {:ok, coo_att} = RefBackend.matrix_to_coo(att)
+
+      assert sort_coo(coo_a) == sort_coo(coo_att)
+    end
+
+    test "transpose of MxN gives NxM" do
+      {:ok, a} = RefBackend.matrix_from_coo(2, 5, [{0, 3, 1}, {1, 4, 2}], :int64, [])
+      {:ok, at} = RefBackend.matrix_transpose(a, [])
+      assert {:ok, {5, 2}} = RefBackend.matrix_shape(at)
+    end
+
+    test "transpose swaps row and column indices" do
+      {:ok, a} = RefBackend.matrix_from_coo(3, 3, [{0, 2, 7}, {1, 0, 8}], :int64, [])
+      {:ok, at} = RefBackend.matrix_transpose(a, [])
+      {:ok, coo} = RefBackend.matrix_to_coo(at)
+      assert sort_coo(coo) == [{0, 1, 8}, {2, 0, 7}]
+    end
+  end
+
+  describe "ewise_add with disjoint entries" do
+    test "nvals(A+B) == nvals(A) + nvals(B) when no overlap" do
+      {:ok, a} = RefBackend.matrix_from_coo(3, 3, [{0, 0, 1}, {1, 1, 2}], :int64, [])
+      {:ok, b} = RefBackend.matrix_from_coo(3, 3, [{2, 2, 3}], :int64, [])
+
+      {:ok, sum} = RefBackend.matrix_ewise_add(a, b, :plus, [])
+      {:ok, nvals} = RefBackend.matrix_nvals(sum)
+
+      assert nvals == 3
+    end
+
+    test "A + empty == A" do
+      entries = [{0, 0, 1}, {1, 1, 2}]
+      {:ok, a} = RefBackend.matrix_from_coo(3, 3, entries, :int64, [])
+      {:ok, empty} = RefBackend.matrix_new(3, 3, :int64, [])
+
+      {:ok, sum} = RefBackend.matrix_ewise_add(a, empty, :plus, [])
+      {:ok, coo_a} = RefBackend.matrix_to_coo(a)
+      {:ok, coo_sum} = RefBackend.matrix_to_coo(sum)
+
+      assert sort_coo(coo_a) == sort_coo(coo_sum)
+    end
+  end
+
+  describe "reduce properties" do
+    test "vector_reduce of single entry returns that value" do
+      {:ok, v} = RefBackend.vector_from_entries(5, [{2, 42}], :int64, [])
+      {:ok, %GraphBLAS.Scalar{value: val}} = RefBackend.vector_reduce(v, :plus, [])
+      assert val == 42
+    end
+
+    test "matrix_reduce sums each row" do
+      {:ok, m} = RefBackend.matrix_from_coo(2, 3, [{0, 0, 1}, {0, 2, 3}, {1, 1, 5}], :int64, [])
+      {:ok, v} = RefBackend.matrix_reduce(m, :plus, [])
+      {:ok, entries} = RefBackend.vector_to_entries(v)
+      assert sort_vec(entries) == [{0, 4}, {1, 5}]
+    end
+  end
+
+  describe "dup independence" do
+    test "matrix_dup produces independent copy" do
+      {:ok, m} = RefBackend.matrix_from_coo(3, 3, [{0, 0, 1}], :int64, [])
+      {:ok, dup} = RefBackend.matrix_dup(m)
+      {:ok, modified} = RefBackend.matrix_set(dup, 1, 1, 99)
+
+      {:ok, orig_coo} = RefBackend.matrix_to_coo(m)
+      {:ok, mod_coo} = RefBackend.matrix_to_coo(modified)
+
+      assert sort_coo(orig_coo) == [{0, 0, 1}]
+      assert sort_coo(mod_coo) == [{0, 0, 1}, {1, 1, 99}]
+    end
+
+    test "vector_dup produces independent copy" do
+      {:ok, v} = RefBackend.vector_from_entries(3, [{0, 10}], :int64, [])
+      {:ok, dup} = RefBackend.vector_dup(v)
+      {:ok, modified} = RefBackend.vector_set(dup, 2, 77)
+
+      {:ok, orig_entries} = RefBackend.vector_to_entries(v)
+      {:ok, mod_entries} = RefBackend.vector_to_entries(modified)
+
+      assert sort_vec(orig_entries) == [{0, 10}]
+      assert sort_vec(mod_entries) == [{0, 10}, {2, 77}]
+    end
+  end
+end

--- a/test/ex_graphblas/backend/parity_test.exs
+++ b/test/ex_graphblas/backend/parity_test.exs
@@ -768,4 +768,13 @@ if System.get_env("EX_GRAPHBLAS_COMPILE_NATIVE") in ["1", "true"] do
       end
     end
   end
+else
+  defmodule GraphBLAS.Backend.ParityTest do
+    use ExUnit.Case
+    @moduletag :skip
+    @tag :native_backend
+    test "skipped: native backend not compiled (set EX_GRAPHBLAS_COMPILE_NATIVE=1)" do
+      :ok
+    end
+  end
 end

--- a/test/ex_graphblas/backend/suite_sparse_test.exs
+++ b/test/ex_graphblas/backend/suite_sparse_test.exs
@@ -1013,4 +1013,13 @@ if System.get_env("EX_GRAPHBLAS_COMPILE_NATIVE") in ["1", "true"] do
       Enum.sort_by(entries, fn {i, _v} -> i end)
     end
   end
+else
+  defmodule GraphBLAS.SuiteSparseBackendTest do
+    use ExUnit.Case
+    @moduletag :skip
+    @tag :native_backend
+    test "skipped: native backend not compiled (set EX_GRAPHBLAS_COMPILE_NATIVE=1)" do
+      :ok
+    end
+  end
 end

--- a/test/ex_graphblas/descriptor_test.exs
+++ b/test/ex_graphblas/descriptor_test.exs
@@ -2,7 +2,7 @@ defmodule GraphBLAS.DescriptorTest do
   use ExUnit.Case, async: true
 
   alias GraphBLAS.Backend.Elixir, as: RefBackend
-  alias GraphBLAS.{Descriptor, Matrix}
+  alias GraphBLAS.Descriptor
 
   describe "new/1" do
     test "creates descriptor with defaults" do

--- a/test/ex_graphblas/edge_case_test.exs
+++ b/test/ex_graphblas/edge_case_test.exs
@@ -1,0 +1,159 @@
+defmodule GraphBLAS.EdgeCaseTest do
+  use ExUnit.Case, async: true
+
+  alias GraphBLAS.Backend.Elixir, as: RefBackend
+  alias GraphBLAS.{Error, Matrix, Vector}
+
+  describe "zero-dimension matrices" do
+    test "matrix_new(0, 0) succeeds" do
+      assert {:ok, %Matrix{shape: {0, 0}}} = RefBackend.matrix_new(0, 0, :int64, [])
+    end
+
+    test "matrix_from_coo(0, 0, []) succeeds" do
+      assert {:ok, %Matrix{shape: {0, 0}}} = RefBackend.matrix_from_coo(0, 0, [], :int64, [])
+    end
+
+    test "nvals of empty 0x0 matrix is 0" do
+      {:ok, m} = RefBackend.matrix_new(0, 0, :int64, [])
+      assert {:ok, 0} = RefBackend.matrix_nvals(m)
+    end
+
+    test "to_coo of empty 0x0 matrix is []" do
+      {:ok, m} = RefBackend.matrix_new(0, 0, :int64, [])
+      assert {:ok, []} = RefBackend.matrix_to_coo(m)
+    end
+
+    test "matrix_new(0, 5) succeeds" do
+      assert {:ok, %Matrix{shape: {0, 5}}} = RefBackend.matrix_new(0, 5, :int64, [])
+    end
+
+    test "matrix_new(5, 0) succeeds" do
+      assert {:ok, %Matrix{shape: {5, 0}}} = RefBackend.matrix_new(5, 0, :int64, [])
+    end
+  end
+
+  describe "zero-size vectors" do
+    test "vector_new(0) succeeds" do
+      assert {:ok, %Vector{size: 0}} = RefBackend.vector_new(0, :int64, [])
+    end
+
+    test "vector_from_entries(0, []) succeeds" do
+      assert {:ok, %Vector{size: 0}} = RefBackend.vector_from_entries(0, [], :int64, [])
+    end
+
+    test "nvals of empty vector is 0" do
+      {:ok, v} = RefBackend.vector_new(0, :int64, [])
+      assert {:ok, 0} = RefBackend.vector_nvals(v)
+    end
+
+    test "to_entries of empty vector is []" do
+      {:ok, v} = RefBackend.vector_new(0, :int64, [])
+      assert {:ok, []} = RefBackend.vector_to_entries(v)
+    end
+  end
+
+  describe "negative dimensions" do
+    test "matrix_new rejects negative nrows" do
+      assert {:error, %Error{reason: {:invalid_argument, _}}} =
+               RefBackend.matrix_new(-1, 3, :int64, [])
+    end
+
+    test "matrix_new rejects negative ncols" do
+      assert {:error, %Error{reason: {:invalid_argument, _}}} =
+               RefBackend.matrix_new(3, -1, :int64, [])
+    end
+
+    test "vector_new rejects negative size" do
+      assert {:error, %Error{reason: {:invalid_argument, _}}} =
+               RefBackend.vector_new(-1, :int64, [])
+    end
+  end
+
+  describe "out-of-bounds column indices" do
+    test "matrix_from_coo rejects out-of-bounds column" do
+      assert {:error, %Error{reason: {:index_out_of_bounds, 5, :col, 2}}} =
+               RefBackend.matrix_from_coo(2, 2, [{0, 5, 1}], :int64, [])
+    end
+
+    test "vector_from_entries rejects out-of-bounds index" do
+      assert {:error, %Error{reason: {:index_out_of_bounds, 5, :index, 2}}} =
+               RefBackend.vector_from_entries(2, [{5, 1}], :int64, [])
+    end
+  end
+
+  describe "dup of empty containers" do
+    test "matrix_dup of empty matrix" do
+      {:ok, m} = RefBackend.matrix_new(3, 3, :int64, [])
+      {:ok, dup} = RefBackend.matrix_dup(m)
+      assert {:ok, 0} = RefBackend.matrix_nvals(dup)
+      assert {:ok, {3, 3}} = RefBackend.matrix_shape(dup)
+    end
+
+    test "vector_dup of empty vector" do
+      {:ok, v} = RefBackend.vector_new(5, :int64, [])
+      {:ok, dup} = RefBackend.vector_dup(v)
+      assert {:ok, 0} = RefBackend.vector_nvals(dup)
+      assert {:ok, 5} = RefBackend.vector_size(dup)
+    end
+  end
+
+  describe "all type variants" do
+    test "matrix_new :int64" do
+      assert {:ok, %Matrix{type: :int64}} = RefBackend.matrix_new(2, 2, :int64, [])
+    end
+
+    test "matrix_new :fp64" do
+      assert {:ok, %Matrix{type: :fp64}} = RefBackend.matrix_new(2, 2, :fp64, [])
+    end
+
+    test "matrix_new :bool" do
+      assert {:ok, %Matrix{type: :bool}} = RefBackend.matrix_new(2, 2, :bool, [])
+    end
+
+    test "vector_new :int64" do
+      assert {:ok, %Vector{type: :int64}} = RefBackend.vector_new(3, :int64, [])
+    end
+
+    test "vector_new :fp64" do
+      assert {:ok, %Vector{type: :fp64}} = RefBackend.vector_new(3, :fp64, [])
+    end
+
+    test "vector_new :bool" do
+      assert {:ok, %Vector{type: :bool}} = RefBackend.vector_new(3, :bool, [])
+    end
+  end
+
+  describe "set on empty containers" do
+    test "matrix_set adds entry to empty matrix" do
+      {:ok, m} = RefBackend.matrix_new(3, 3, :int64, [])
+      {:ok, m2} = RefBackend.matrix_set(m, 1, 2, 42)
+      assert {:ok, 1} = RefBackend.matrix_nvals(m2)
+      {:ok, coo} = RefBackend.matrix_to_coo(m2)
+      assert [{1, 2, 42}] = coo
+    end
+
+    test "vector_set adds entry to empty vector" do
+      {:ok, v} = RefBackend.vector_new(5, :int64, [])
+      {:ok, v2} = RefBackend.vector_set(v, 3, 99)
+      assert {:ok, 1} = RefBackend.vector_nvals(v2)
+      {:ok, entries} = RefBackend.vector_to_entries(v2)
+      assert [{3, 99}] = entries
+    end
+  end
+
+  describe "to_dense of empty matrix" do
+    test "returns grid of default values" do
+      {:ok, m} = RefBackend.matrix_new(2, 3, :int64, [])
+      {:ok, dense} = RefBackend.matrix_to_dense(m)
+      assert dense == [[0, 0, 0], [0, 0, 0]]
+    end
+  end
+
+  describe "to_list of empty vector" do
+    test "returns list of default values" do
+      {:ok, v} = RefBackend.vector_new(3, :fp64, [])
+      {:ok, list} = RefBackend.vector_to_list(v)
+      assert list == [0.0, 0.0, 0.0]
+    end
+  end
+end

--- a/test/ex_graphblas/mask_test.exs
+++ b/test/ex_graphblas/mask_test.exs
@@ -2,7 +2,7 @@ defmodule GraphBLAS.MaskTest do
   use ExUnit.Case, async: true
 
   alias GraphBLAS.Backend.Elixir, as: RefBackend
-  alias GraphBLAS.{Mask, Matrix, Vector}
+  alias GraphBLAS.{Mask, Matrix}
 
   describe "new/2" do
     test "creates a structural mask from a matrix" do

--- a/test/ex_graphblas/property_test.exs
+++ b/test/ex_graphblas/property_test.exs
@@ -605,4 +605,13 @@ if System.get_env("EX_GRAPHBLAS_COMPILE_NATIVE") in ["1", "true"] do
       end)
     end
   end
+else
+  defmodule GraphBLAS.PropertyTest do
+    use ExUnit.Case
+    @moduletag :skip
+    @tag :native_backend
+    test "skipped: native backend not compiled (set EX_GRAPHBLAS_COMPILE_NATIVE=1)" do
+      :ok
+    end
+  end
 end


### PR DESCRIPTION
# Pre-Release Code Review: ex_graphblas v0.2.0

**Date**: 2026-04-25
**Reviewer**: Sisyphus (automated)
**Scope**: Full branch review — lib/, native/, test/, docs, CI, mix.exs
**Purpose**: Identify and prioritize issues before first Hex.pm release

---

## Executive Summary

The codebase is well-structured with good type safety, consistent error handling, and a solid backend abstraction. The three-backend architecture (Elixir, SuiteSparse, ZigStub) is clean and the `@behaviour GraphBLAS.Backend` contract is well-defined with 30 callbacks. However, there are significant issues across resource management, documentation accuracy, package metadata, and test coverage that must be addressed before publishing to Hex.pm.

**Issue counts by severity:**

| Severity | Count | Description |
|----------|-------|-------------|
| P0 — Release Blockers | 4 | Will break Hex.pm listing, cause memory leaks, or undefined behavior |
| P1 — High Priority | 9 | Incorrect docs, unsafe code, missing specs |
| P2 — Moderate Priority | 12 | Test gaps, CI issues, config problems |
| P3 — Low Priority | 6 | Polish, minor inconsistencies |

---

## P0 — Release Blockers

### 1. mix.exs Package Metadata (will break Hex.pm listing)

| Issue | File:Line | Fix |
|-------|-----------|-----|
| `source_url` missing from `project()` | mix.exs:16-60 | Add `source_url: @source_url` to project list |
| `source_url` missing from `docs:` config | mix.exs:38-55 | Add `source_url: @source_url` to docs config |
| `files:` commented out — package will include `native/`, `bench/`, Zig staging files | mix.exs:105 | Uncomment and set: `files: ~w(lib priv .formatter.exs mix.exs README.md LICENSE CHANGELOG.md)` |
| Prod `elixirc_paths` includes `"native"` — users without SuiteSparse can't compile | mix.exs:94 | Change to `defp elixirc_paths(_), do: ["lib"]` |

**Why this is P0:** Without `source_url`, ExDoc generates docs without GitHub source links. Without explicit `files:`, the Hex package includes 795-line Zig NIF source code, benchmark files, and Zigler staging artifacts. Users who `mix deps.get` the package will fail to compile because `native/suite_sparse.ex` uses `use ZiglerPrecompiled` which requires SuiteSparse headers.

---

### 2. Resource Leaks in SuiteSparse Backend (memory leak in production)

Transposed matrices created by `maybe_transpose_inp0/inp1` in `matrix_mxm`, `matrix_mxv`, `vector_vxm` are **never freed**. Every call with a transpose descriptor leaks a `GrB_Matrix`.

| Function | File:Line |
|----------|-----------|
| `matrix_mxm` | native/suite_sparse_backend.ex:122-123 |
| `matrix_mxv` | native/suite_sparse_backend.ex:151 |
| `vector_vxm` | native/suite_sparse_backend.ex:410 |

**Root cause:** `maybe_transpose_inp0` and `maybe_transpose_inp1` (lines 671-697) call `matrix_transpose()` which allocates a new SuiteSparse matrix. The pointer is used for the NIF call but never freed afterward. The variables `_a`, `_b`, `_matrix` are captured with `_` prefix (acknowledging they're unused) but this is the code smell — they should be freed.

**Fix:** Track which pointers were transposed and free them after the operation:

```elixir
{a_ptr, a_transposed} = maybe_transpose_inp0(a, desc)
{b_ptr, b_transposed} = maybe_transpose_inp1(b, desc)
try do
  ptr = GraphBLAS.Native.SuiteSparse.matrix_mxm(a_ptr, b_ptr, semiring_code, desc_ptr)
  # ... build result ...
after
  if a_transposed, do: GraphBLAS.Native.SuiteSparse.matrix_free(a_ptr)
  if b_transposed, do: GraphBLAS.Native.SuiteSparse.matrix_free(b_ptr)
  cleanup_descriptor(desc_ptr)
end
```

**Impact:** Unbounded memory growth in any application using transpose descriptors.

---

### 3. Ignored Error Codes in Zig NIFs (undefined behavior)

Multiple `GrB_Matrix_nrows`, `GrB_Matrix_ncols`, `GxB_Matrix_type` calls discard return values with `_ = ...`, leaving variables uninitialized on failure. If the GrB call fails, the variable declared with `undefined` is used in subsequent operations — classic undefined behavior.

| Location | File:Line | Variable Left Uninitialized |
|----------|-----------|----------------------------|
| matrix_mxm nrows_a, ncols_b | graphblas.zig:440-441 | `nrows_a`, `ncols_b` |
| matrix_mxv nrows | graphblas.zig:462 | `nrows` |
| matrix_ewise_add nrows/ncols | graphblas.zig:480-483 | `nrows`, `ncols` |
| matrix_ewise_mult nrows/ncols | graphblas.zig:503-506 | `nrows`, `ncols` |
| matrix_transpose nrows/ncols | graphblas.zig:526-529 | `nrows`, `ncols` |
| matrix_reduce_to_vector nrows | graphblas.zig:549 | `nrows` |
| vector_ewise_add size | graphblas.zig:670-671 | `size` |
| vector_ewise_mult size | graphblas.zig:691-692 | `size` |
| vector_vxm ncols | graphblas.zig:712-713 | `ncols` |
| descriptor_create set calls | graphblas.zig:820-837 | descriptor in partial state |

**Fix:** Replace all `_ = GrB_Matrix_nrows(...)` with `try translate_info(GrB_Matrix_nrows(...))`.

**Note:** Contrast with `matrix_nrows()` at line 329 which correctly does:
```zig
const info = GrB_Matrix_nrows(&nrows, matrix);
try translate_info(info);
```

---

### 4. Silent Type Defaults in Zig (wrong results, not crashes)

Invalid type/semiring/monoid codes silently default to INT64 variants instead of returning errors. An fp64 operation accidentally passed with an invalid code would compute using INT64 arithmetic and return wrong results with no error.

| Function | File:Line | Silent Default |
|----------|-----------|----------------|
| `type_code_to_grb_type` | graphblas.zig:234 | `else => GrB_INT64` |
| `semiring_from_code` | graphblas.zig:250 | `else => GrB_PLUS_TIMES_SEMIRING_INT64` |
| `monoid_from_code` | graphblas.zig:267 | `else => GrB_PLUS_MONOID_INT64` |

**Fix:** Return an error for unknown codes and surface it as `{:error, %Error{reason: {:invalid_argument, code}}}` to Elixir.

---

## P1 — High Priority (fix before release)

### 5. Documentation Outdated / Incorrect

| Issue | File | Detail |
|-------|------|--------|
| Architecture walkthrough says masks/descriptors are "coming" | guides/architecture_walkthrough.md:189-211 | They're fully implemented since Phase 5. Remove "what's coming" language, update to reflect current state |
| Native backend walkthrough uses wrong module names | guides/native_backend_walkthrough.md:34,118,142 | `SuiteSparse.matrix_free()` should be `GraphBLAS.Backend.SuiteSparse.matrix_free()` |
| Installation guide says GraphBLAS >= 7.0 | guides/installation_guide.md:182 | Should say v9.4.5 — Ubuntu 22.04's v7.4.0 package is missing `GrB_Descriptor_set_INT32` |
| README doesn't mention ZigStub backend | README.md:11,44-46 | Add ZigStub to architecture section |
| README doesn't document env vars | README.md | Add reference for `EX_GRAPHBLAS_COMPILE_NATIVE` and `EX_GRAPHBLAS_BUILD` |
| Elixir version mismatch | mix.exs:20 vs installation_guide.md:7 | mix.exs says `~> 1.17`, guide says `>= 1.18` — reconcile |
| Architecture walkthrough lists Phase 2-6 as "next steps" | guides/architecture_walkthrough.md:215-220 | README shows Phase 6 complete — update |
| Parity testing guide test counts wrong | guides/parity_testing_guide.md:134-156 | Shows "~20", "~25" but actual count is 350+ |
| macOS Intel path not documented | guides/installation_guide.md:35-41 | Only mentions `/opt/homebrew` (Apple Silicon), Intel uses `/usr/local` |

### 6. Unsafe `hd()` Call

`algorithm.ex:259` calls `hd(unvisited_entries)` which crashes on empty list. The `nvals == 0` check above (line 257) should prevent this, but a defensive pattern match is safer:

```elixir
# Instead of:
{v, _} = hd(unvisited_entries)

# Use:
[{v, _} | _] = unvisited_entries
```

### 7. Missing @doc/@spec in SuiteSparse Backend

`native/suite_sparse_backend.ex` has 30 `@impl GraphBLAS.Backend` callback functions with **zero** `@doc` or `@spec` annotations. These functions appear in generated ExDoc documentation as undocumented.

**Affected functions (all in native/suite_sparse_backend.ex):**
Lines 56, 71, 86, 94, 97, 100, 117, 146, 171, 196, 221, 242, 261, 282, 305, 328, 346, 360, 374, 382, 385, 388, 405, 430, 455, 480, 500, 519, 540, 561

Only `matrix_free` (line 580) and `vector_free` (line 591) have specs.

### 8. Unprotected NIF Calls Outside try/rescue

Several NIF calls in `suite_sparse_backend.ex` are outside `try/rescue` blocks. If the NIF crashes, the exception propagates unhandled:

| Call | File:Line | Context |
|------|-----------|---------|
| `matrix_nvals(ptr)` | native/suite_sparse_backend.ex:101 | Before `matrix_to_coo` extract |
| `matrix_nrows(ptr)` | native/suite_sparse_backend.ex:132 | After `matrix_mxm` NIF |
| `matrix_ncols(ptr)` | native/suite_sparse_backend.ex:133 | After `matrix_mxm` NIF |
| `vector_size(ptr)` | native/suite_sparse_backend.ex:160 | After `matrix_mxv` NIF |
| `matrix_nrows(ptr)` | native/suite_sparse_backend.ex:231 | After `matrix_reduce` NIF |
| `vector_nvals(ptr)` | native/suite_sparse_backend.ex:389 | Before `vector_to_entries` extract |

### 9. Missing Input Validation in Zig Build Functions

The `nvals` parameter is passed separately from array slices. If `nvals` doesn't match `rows.len`, `cols.len`, or `vals.len`, the C function will read past array bounds:

| Function | File:Line |
|----------|-----------|
| `matrix_build_int64` | graphblas.zig:355-359 |
| `matrix_build_fp64` | graphblas.zig:361-365 |
| `matrix_build_bool` | graphblas.zig:367-371 |
| `vector_build_int64` | graphblas.zig:605-609 |
| `vector_build_fp64` | graphblas.zig:611-615 |
| `vector_build_bool` | graphblas.zig:617-621 |

**Fix:** Add assertions: `std.debug.assert(nvals <= rows.len and nvals <= cols.len and nvals <= vals.len)`

### 10. Closure Loop Limit Hardcoded

`relation.ex:265` hardcodes `100` as max iterations for the closure loop. Should be configurable via `opts`:

```elixir
# Current:
defp closure_loop(_, _, _, _, i) when i >= 100, do: {:ok, :max_iter}

# Fix:
defp closure_loop(_, _, _, _, i, max_iter) when i >= max_iter, do: {:ok, :max_iter}
```

### 11. `@sssp_inf` Not Configurable

`algorithm.ex:29` defines `@sssp_inf 1.0e18` as a module attribute. This should be configurable via `opts` in `sssp/3` for users with different scale requirements.

### 12. GrB_finalize and JIT Disable Errors Ignored

| Call | File:Line | Issue |
|------|-----------|-------|
| `GrB_finalize()` | graphblas.zig:302 | Return code discarded with `_ =` |
| `GxB_Global_Option_set_INT32(GxB_JIT_C_CONTROL, GxB_JIT_OFF)` | graphblas.zig:298 | Return code discarded — JIT may remain on |

### 13. ZigStub Backend Doesn't Validate Dimensions

`lib/ex_graphblas/backend/zig_stub.ex` lines 79-87 (`matrix_new`) and 134-142 (`vector_new`) don't validate that `nrows`, `ncols`, and `size` are non-negative. The Elixir backend validates these (elixir.ex:336-347), creating inconsistent behavior between backends.

---

## P2 — Moderate Priority (fix for quality)

### 14. Test Gaps — Missing Edge Cases

| Gap | Impact |
|-----|--------|
| No tests for empty/zero-dimension matrices in algorithms | Crashes on edge cases |
| No type mismatch error tests (int64 matrix + fp64 matrix in mxm) | Silent wrong results |
| Weak assertions: `assert entries != []` (algorithm_test.exs:310), `assert is_list(result)` (algorithm_test.exs:452) | Tests pass on wrong results |
| Missing boundary value tests: INT64_MAX, INT64_MIN, NaN, infinity | Overflow bugs |
| Missing negative/out-of-bounds index tests in matrix_from_coo, vector_from_entries | Input validation gaps |
| Missing mask + descriptor combination tests (complement mask + replace output) | Untested code paths |
| Missing tests for `matrix_set` type coercion (int into fp64 matrix) | Type handling bugs |
| ZigStub backend tests rely on `available?()` but no test for unavailable case | Incomplete coverage |

### 15. Test Gaps — Missing Mathematical Property Tests

The property_test.exs file has 25 property-based tests but misses fundamental algebraic properties:

| Property | Status |
|----------|--------|
| Associativity: (A * B) * C = A * (B * C) | NOT TESTED |
| Commutativity: A + B = B + A for ewise_add | NOT TESTED |
| Distributivity: A * (B + C) = (A * B) + (A * C) | NOT TESTED |
| Identity: I * A = A | NOT TESTED |
| Transpose: (A^T)^T = A | NOT TESTED |
| Transpose: (A * B)^T = B^T * A^T | NOT TESTED |
| Reduction: reduce(A + B) = reduce(A) + reduce(B) for plus monoid | NOT TESTED |

### 16. Test Gaps — Incomplete Backend Callback Coverage

~24/30 backend callbacks are tested. Missing or incomplete:

| Callback | Issue |
|----------|-------|
| `matrix_new/4` | Missing: large dimensions, negative dimensions, all 3 type variants |
| `matrix_from_coo/5` | Missing: duplicate entries with combine_monoid, out-of-bounds col indices, negative indices |
| `vector_from_entries/4` | Missing: duplicate entries, negative indices |
| `matrix_set/4`, `vector_set/3` | Missing: type coercion, boundary values, setting defaults (0, false) |
| `matrix_dup/1`, `vector_dup/1` | Missing: dup of empty container |

### 17. CI Workflow Issues

| Issue | File | Fix |
|-------|------|-----|
| Coverage flag declared but never used | elixir-build.yml:28 vs 69 | Add `--cover` to `mix test` when `matrix.coverage == true` |
| `2>/dev/null` swallows checksum download errors | precompiled-nifs.yml:252 | Remove `2>/dev/null`, check exit code |
| Publish job uses Elixir 1.18.4/OTP 27 vs lint's 1.19.5/OTP 28.4.1 | precompiled-nifs.yml:224-225 | Align versions |
| `excoveralls` missing `runtime: false` | mix.exs:76 | Add `runtime: false` |
| Formatter doesn't cover `native/` or `bench/` | .formatter.exs:3 | Add to inputs glob |

### 18. Config Issues

| Issue | File:Line | Fix |
|-------|-----------|-----|
| `config/dev.exs` hardcodes `force_build_all: true` | dev.exs:6-9 | Make conditional on `EX_GRAPHBLAS_BUILD` env var |
| `config/prod.exs` defaults to Elixir backend | prod.exs:3-4 | Document why, or change to SuiteSparse |
| No runtime config documentation for `suitesparse_include_path` | prod.exs | Add example showing how to configure |

### 19. SuiteSparse Test Guards Lack Skip Messages

Tests in `parity_test.exs`, `suite_sparse_test.exs`, `property_test.exs` are guarded with `if System.get_env("EX_GRAPHBLAS_COMPILE_NATIVE")`, but when native is not compiled, tests silently disappear. No indication in test output that native tests were skipped.

**Fix:** Add explicit skip module:

```elixir
if System.get_env("EX_GRAPHBLAS_COMPILE_NATIVE") in ["1", "true"] do
  defmodule GraphBLAS.Backend.ParityTest do
    # ... tests ...
  end
else
  defmodule GraphBLAS.Backend.ParityTest do
    use ExUnit.Case
    @moduletag :skip
    test "skipped: native backend not compiled (set EX_GRAPHBLAS_COMPILE_NATIVE=1)" do
      :ok
    end
  end
end
```

### 20. Missing Error Handling Documentation

| Function | File:Line | Issue |
|----------|-----------|-------|
| `BinaryOp.fn_for/1` | binary_op.ex:70 | Raises `ArgumentError` on unknown op but @doc doesn't mention it |
| `UnaryOp.fn_for/1` | unary_op.ex:68 | Same — raises but undocumented |
| `BinaryOp.new/1` | binary_op.ex:39-41 | Uses `Keyword.fetch!` — raises `KeyError` on missing keys but @doc doesn't say |
| `Monoid.new/1` | monoid.ex:51-54 | Same |
| `Semiring.new/1` | semiring.ex:74-79 | Same |
| `UnaryOp.new/1` | unary_op.ex:42-44 | Same |

### 21. Incomplete @moduledoc

| Module | File:Line | Issue |
|--------|-----------|-------|
| `GraphBLAS.Helpers` | helpers.ex:2 | `@moduledoc false` — should explain internal utilities |
| `GraphBLAS.Application` | application.ex:2 | `@moduledoc false` — should explain SuiteSparse init/finalize lifecycle |

### 22. Application.ex Silently Swallows Errors

`application.ex` lines 10-16 and 29-35 use bare `try/rescue` catching all exceptions from `grb_init()` and `grb_finalize()`. Errors are silently discarded. Should at minimum log with `Logger.debug`.

---

## P3 — Low Priority (polish)

### 23. Duplicate Constants

Int64/fp64 limit constants are duplicated between `monoid.ex` (lines 122-123) and `scalar.ex` (lines 102-108). Consider extracting to a shared `GraphBLAS.Constants` module.

### 24. Algorithm fixed_point Documentation Incomplete

`algorithm.ex:405` — @doc for `fixed_point/3` mentions `convergence_fn` option but doesn't explain default behavior (exact comparison for matrices, tolerance-based for vectors).

### 25. Relation Documentation Missing Backend Inheritance

`relation.ex:55` (`add_triples/4`) and `relation.ex:92` (`add_weighted_triples/5`) — @doc doesn't mention that when extending an existing predicate, the backend is inherited from the existing matrix.

### 26. Descriptor Cleanup Logic Fragile

`native/suite_sparse_backend.ex:752-758` — `cleanup_descriptor` checks `descriptor_is_custom()` to decide whether to free. This relies on the Zig code correctly identifying custom vs. predefined descriptors. If the Zig code has a bug, descriptors will leak or be double-freed.

### 27. Default SuiteSparse Include Path is macOS-Only

`native/suite_sparse.ex:30-37` — Hardcoded default path `/opt/homebrew/include/suitesparse` is macOS Apple Silicon-specific. Linux and Intel Mac users must set the env var or config. Should be documented prominently.

### 28. Missing No-Op Documentation

`guides/masks_and_descriptors_guide.md:105-112` — `replace_output()` descriptor is documented as "no-op" and "for future in-place operations". Should clearly state this is not yet functional.

---

## Recommended Fix Order

| Step | Items | Estimated Effort |
|------|-------|-----------------|
| 1 | mix.exs metadata (#1) | 30 min |
| 2 | Resource leak fix (#2) | 2 hrs |
| 3 | Zig error handling (#3, #4, #9, #12) | 3 hrs |
| 4 | Documentation fixes (#5) | 2 hrs |
| 5 | Unsafe `hd()` fix (#6) | 10 min |
| 6 | SuiteSparse backend @doc/@spec (#7) | 2 hrs |
| 7 | Unprotected NIF calls (#8) | 1 hr |
| 8 | Configurable limits (#10, #11) | 30 min |
| 9 | ZigStub dimension validation (#13) | 15 min |
| 10 | CI fixes (#17) | 1 hr |
| 11 | Test gaps — edge cases (#14) | 4 hrs |
| 12 | Test gaps — property tests (#15) | 4 hrs |
| 13 | Test gaps — callback coverage (#16) | 4 hrs |
| 14 | Config and remaining P2 items (#18-22) | 2 hrs |
| 15 | P3 polish items (#23-28) | 2 hrs |
| **Total** | | **~28 hrs** |

---

## Files Reviewed

### lib/

- lib/ex_graphblas.ex
- lib/ex_graphblas/algorithm.ex
- lib/ex_graphblas/backend.ex
- lib/ex_graphblas/backend/elixir.ex
- lib/ex_graphblas/backend/zig_stub.ex
- lib/ex_graphblas/binary_op.ex
- lib/ex_graphblas/config.ex
- lib/ex_graphblas/descriptor.ex
- lib/ex_graphblas/error.ex
- lib/ex_graphblas/helpers.ex
- lib/ex_graphblas/mask.ex
- lib/ex_graphblas/matrix.ex
- lib/ex_graphblas/monoid.ex
- lib/ex_graphblas/nif/zig_stub.ex
- lib/ex_graphblas/relation.ex
- lib/ex_graphblas/scalar.ex
- lib/ex_graphblas/semiring.ex
- lib/ex_graphblas/types.ex
- lib/ex_graphblas/unary_op.ex
- lib/ex_graphblas/vector.ex
- lib/graph_blas/application.ex

### native/

- native/suite_sparse.ex
- native/suite_sparse_backend.ex

### priv/

- priv/native/suite_sparse/graphblas.zig
- priv/native/zig_stub/zig_stub.zig

### test/

- test/ex_graphblas/algorithm_test.exs
- test/ex_graphblas/application_test.exs
- test/ex_graphblas/backend/elixir_test.exs
- test/ex_graphblas/backend/parity_test.exs
- test/ex_graphblas/backend/semantic_correctness_test.exs
- test/ex_graphblas/backend/suite_sparse_test.exs
- test/ex_graphblas/binary_op_test.exs
- test/ex_graphblas/config_test.exs
- test/ex_graphblas/descriptor_test.exs
- test/ex_graphblas/error_test.exs
- test/ex_graphblas/helpers_test.exs
- test/ex_graphblas/mask_test.exs
- test/ex_graphblas/matrix_api_test.exs
- test/ex_graphblas/monoid_test.exs
- test/ex_graphblas/property_test.exs
- test/ex_graphblas/relation_test.exs
- test/ex_graphblas/scalar_test.exs
- test/ex_graphblas/semiring_test.exs
- test/ex_graphblas/top_level_test.exs
- test/ex_graphblas/types_test.exs
- test/ex_graphblas/unary_op_test.exs
- test/ex_graphblas/vector_api_test.exs
- test/ex_graphblas/zig_stub_test.exs

### docs/

- README.md
- CHANGELOG.md
- CONTRIBUTING.md
- LICENSE
- guides/architecture_walkthrough.md
- guides/graph_algorithms_guide.md
- guides/installation_guide.md
- guides/masks_and_descriptors_guide.md
- guides/native_backend_walkthrough.md
- guides/parity_testing_guide.md
- guides/reference_backend_walkthrough.md

### config/

- config/config.exs
- config/dev.exs
- config/test.exs
- config/prod.exs

### CI/tooling

- .github/workflows/elixir-build.yml
- .github/workflows/lint.yml
- .github/workflows/precompiled-nifs.yml
- .credo.exs
- .formatter.exs
- mix.exs

---

## What Passed Review

These areas are well-implemented and need no changes:

- **Backend abstraction**: Clean `@behaviour` with 30 callbacks, consistent across all 3 backends
- **Error module**: Structured errors with `GraphBLAS.Error`, proper `reason` types, `format_reason/1` coverage
- **Type system**: `Types.validate_scalar_type/1`, consistent `:int64`/`:fp64`/`:bool` support
- **Config module**: Centralized backend selection with per-call overrides
- **Resource cleanup**: `Helpers.maybe_free/2` properly dispatches cleanup per backend
- **Guards and validation**: Elixir backend has thorough guards (`validate_dimensions/2`, `validate_size/1`, `validate_index/2`)
- **All public functions have @spec** in lib/ (excluding native/ backend)
- **Credo configuration**: Well-tuned with appropriate exclusions
- **No dead code detected** across the entire codebase
